### PR TITLE
Allow longer URLs

### DIFF
--- a/db/migrate/20130504005816_text_url.rb
+++ b/db/migrate/20130504005816_text_url.rb
@@ -1,0 +1,9 @@
+class TextUrl < ActiveRecord::Migration
+  def up
+    change_column :feeds, :url, :text
+  end
+
+  def down
+    change_column :feeds, :url, :string
+  end
+end


### PR DESCRIPTION
The PostgreSQL 'string' on Heroku only allows 255 characters. Use 'text' instead to allow longer URLs.
