### PR TITLE
Swap "j" and "k" to move down/up instead of up/down.

### DIFF
--- a/app/public/js/app.js
+++ b/app/public/js/app.js
@@ -88,7 +88,7 @@ $(document).ready(function() {
   var cursorPosition = -1;
   var MAX_POSITION = $("li.story").size();
 
-  Mousetrap.bind("k", function() {
+  Mousetrap.bind("j", function() {
     if (cursorPosition < MAX_POSITION - 1) {
       cursorPosition++;
       
@@ -97,7 +97,7 @@ $(document).ready(function() {
     }
   });
 
-  Mousetrap.bind("j", function() {
+  Mousetrap.bind("k", function() {
     $("li.story").removeClass("cursor");
 
     if (cursorPosition > 0) {


### PR DESCRIPTION
j/k always was for down/up in google reader
which is same as in vim.

Avoids confusion for users migrating from google reader.
