### PR TITLE
keep_stories_unread

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -8,9 +8,9 @@ class Stringer < Sinatra::Base
     erb :index
   end
 
-  post "/mark_as_read" do
+  post "/mark_story" do
     story = StoryRepository.fetch(params[:story_id])
-    story.is_read = true
+    story.is_read = (params[:is_read] == 'true')
     StoryRepository.save(story)
   end
 

--- a/app/public/js/app.js
+++ b/app/public/js/app.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
 
     if($this.hasClass("open")) {
       $this.removeClass("open");
-      $this.addClass("read");
+      if (!e.keepUnread) { $this.addClass("read") };
 
       $(".story-lead", this).show();
       $(".story-body-container", this).stop().hide();
@@ -38,7 +38,7 @@ $(document).ready(function() {
     var storyId = $this.data("id");
 
     if (storyId > 0) {
-      $.post("/mark_as_read", { story_id: storyId })
+      $.post("/mark_story", { story_id: storyId, is_read: true })
        .fail(function() { alert("something broke!"); });
     }
   });
@@ -145,5 +145,19 @@ $(document).ready(function() {
     var permalink = currentStory.find("a.story-permalink")[0];
 
     if (permalink) window.open(permalink.href, '_blank');
+  });
+
+  Mousetrap.bind("m", function() {
+    var openStories = $("li.story.open");
+    openStories.each(function() {
+      $this = $(this);
+      var storyId = $this.data("id");
+
+      if (storyId > 0) {
+        $.post("/mark_story", { story_id: storyId, is_read: false })
+         .fail(function() { alert("something broke!"); });
+      }
+      openStories.trigger({type: "closeStory", keepUnread: true});
+    });
   });
 });

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -55,15 +55,19 @@ describe "StoriesController" do
     end
   end
 
-  describe "/mark_as_read" do
+  describe "/mark_story" do
     before { StoryRepository.stub(:fetch).and_return(story_one) }
 
     it "marks a story as read" do
       StoryRepository.should_receive(:save).once
-
-      post "/mark_as_read", {story_id: story_one.id}.to_json
-
+      post "/mark_story", {story_id: story_one.id, is_read: true}
       story_one.is_read.should be_true
+    end
+
+    it "marks a story as un-read" do
+      StoryRepository.should_receive(:save).once
+      post "/mark_story", {story_id: story_one.id, is_read: false}
+      story_one.is_read.should be_false
     end
   end
 


### PR DESCRIPTION
This partially addresses #47.

Pressing 'm' now collapses the story and marks it un-read.

I don't have time to implement a UI component to this, but I will do that (and update the docs) this weekend.

This is my first contribution so feel free to provide any comments or feedback!  Thanks!
