### PR TITLE
Add width constant to guarantee visibility of remove button for feeds

### DIFF
--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -311,6 +311,7 @@ li.feed .last-updated-time {
 
 li.feed .remove-feed {
   cursor: pointer;
+  width: 5%;
 }
 
 li.feed .remove-feed a {


### PR DESCRIPTION
As already mentioned in #60, this change solves the problem of the remove button not showing on screens/browser windows bigger than 1200px.
