### PR TITLE
Cookies required message.

### DIFF
--- a/app/controllers/first_run_controller.rb
+++ b/app/controllers/first_run_controller.rb
@@ -30,11 +30,19 @@ class Stringer < Sinatra::Base
     end
 
     get "/tutorial" do
-      FetchFeeds.enqueue(Feed.all)
-      CompleteSetup.complete(current_user)
+      if current_user
+        FetchFeeds.enqueue(Feed.all)
+        CompleteSetup.complete(current_user)
 
-      @sample_stories = StoryRepository.samples
-      erb :tutorial
+        @sample_stories = StoryRepository.samples
+        erb :tutorial
+      else
+        redirect to("/setup/cookies")
+      end
+    end
+
+    get "/cookies" do
+      erb :"first_run/cookies"
     end
   end
 

--- a/app/views/first_run/cookies.erb
+++ b/app/views/first_run/cookies.erb
@@ -1,0 +1,5 @@
+<div class="setup" id="password-setup">
+  <h1><%= t 'first_run.cookies.title' %></h1>
+  <hr />
+  <h2><%= t 'first_run.cookies.subtitle' %></h2>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,9 @@ en:
         next: "Next"
       flash:
         passwords_dont_match: "Hey, your password confirmation didn't match. Try again."
+    cookies:
+      title: "Stringer requires cookies."
+      subtitle: "Please whitelist cookies on this domain."
   partials:
     action_bar:
       mark_all: "Mark all as read"

--- a/spec/controllers/first_run_controller_spec.rb
+++ b/spec/controllers/first_run_controller_spec.rb
@@ -49,7 +49,7 @@ describe "FirstRunController" do
       let(:user) { stub }
       let(:feeds) {[stub, stub]}
 
-      before do 
+      before do
         UserRepository.stub(fetch: user)
         Feed.stub(all: feeds)
       end
@@ -57,7 +57,7 @@ describe "FirstRunController" do
       it "displays the tutorial and completes setup" do
         CompleteSetup.should_receive(:complete).with(user).once
         FetchFeeds.should_receive(:enqueue).with(feeds).once
-        
+
         get "/setup/tutorial"
 
         page = last_response.body
@@ -67,6 +67,18 @@ describe "FirstRunController" do
         page.should have_tag("#add-feed-instruction")
         page.should have_tag("#story-instruction")
         page.should have_tag("#start")
+      end
+
+      context "When cookies are disabled" do
+        before do
+          UserRepository.stub(:fetch).and_return(nil)
+        end
+
+        it "redirects to the cookies page" do
+          get "/setup/tutorial"
+          last_response.status.should be 302
+          URI::parse(last_response.location).path.should eq "/setup/cookies"
+        end
       end
     end
   end


### PR DESCRIPTION
When attempting the first signup flow, if your browser does not have cookies whitelisted on the stringer domain, the app will throw an exception.

This probably isn't the best solution, but it gives a more friendly message than a 500 error.

![screen shot 2013-05-11 at 11 09 30 pm](https://f.cloud.github.com/assets/1817/492600/93709a52-baca-11e2-82a5-2e9795b4f4c4.png)
