### PR TITLE
Skip sintra-assetpack prebuild during tests (faster)

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -78,7 +78,7 @@ class Stringer < Sinatra::Base
     js_compression  :uglify
     css_compression :simple
 
-    prebuild true
+    prebuild true if ENV['RACK_ENV'] != 'test'
     cache_dynamic_assets true
   }
 


### PR DESCRIPTION
Regarding https://github.com/rstacruz/sinatra-assetpack/issues/101 I think removing the prebuild in test env should do it. 

The prebuild is triggered when the app is loaded, and you are doing so in the tests since you are using an instance of your sinatra app :

https://github.com/swanson/stringer/blob/master/spec/spec_helper.rb#L28
