### PR TITLE
perform fetch_feeds with thread pool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "feedbag", github: "dwillis/feedbag"
 gem "coveralls", require: false
 gem "uglifier"
 gem "highline", require: false
+gem "thread"
 
 group :production do
   gem "unicorn"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,7 @@ GEM
     slop (3.4.4)
     sqlite3 (1.3.7)
     thor (0.18.1)
+    thread (0.0.8)
     tilt (1.4.1)
     tzinfo (0.3.37)
     uglifier (2.1.0)
@@ -173,6 +174,7 @@ DEPENDENCIES
   sinatra-contrib!
   sinatra-flash
   sqlite3
+  thread
   uglifier
   unicorn
   will_paginate

--- a/app/tasks/fetch_feeds.rb
+++ b/app/tasks/fetch_feeds.rb
@@ -1,3 +1,4 @@
+require 'thread/pool'
 require_relative "fetch_feed"
 
 class FetchFeeds
@@ -6,9 +7,15 @@ class FetchFeeds
   end
 
   def fetch_all
+    pool = Thread.pool(10)
+
     @feeds.each do |feed|
-      FetchFeed.new(feed).fetch
+      pool.process do
+        FetchFeed.new(feed).fetch
+      end
     end
+
+    pool.shutdown
   end
 
   def self.enqueue(feeds)


### PR DESCRIPTION
For my list of rss feeds the time consumed to fetch all of them is reduced by up to 200%

From ~9minute down to 3-5 minutes.

With faster fetching you can
- fetch more often
- save time (and money) on heroku (I don't like to pay for waiting on http responses ;-))
