### PR TITLE
Extract FeedDiscovery#get_feed_for_url to eliminate redundant `rescue` clauses.

### DIFF
--- a/app/utils/feed_discovery.rb
+++ b/app/utils/feed_discovery.rb
@@ -3,7 +3,7 @@ require "feedzirra"
 
 class FeedDiscovery
   def discover(url, finder = Feedbag, parser = Feedzirra::Feed)
-    feed = get_feed_for_url(url, finder, parser) do
+    get_feed_for_url(url, finder, parser) do
       urls = finder.find(url)
       return false if urls.empty?
 
@@ -11,7 +11,6 @@ class FeedDiscovery
         return false
       end
     end
-    feed
   end
 
   def get_feed_for_url(url, finder, parser)


### PR DESCRIPTION
By the way, `rescue Exception` is nearly always a bad idea. Do you
happen to know _which_ exceptions may be raised? Is it just the usual
collection of IO errors and HTTP errors that might be raised by an
HTTP request?
