### PR TITLE
change link to external rss url in feed listing

### DIFF
--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -327,15 +327,27 @@ li.feed .last-updated-time {
   display: inline-block;
 }
 
+li.feed .feed-url-link a {
+  color: #484948;
+  text-decoration: none;
+  text-align: center;
+  padding-left: 2px;
+  padding-right: 2px;
+}
+
+li.feed .feed-url-link a:hover {
+  color: #7F8281;
+}
+
 li.feed .remove-feed {
   cursor: pointer;
 }
 
 li.feed .remove-feed a {
   text-align: center;
-  padding-left: 3px;
-  padding-right: 3px;
-  margin-left: 10px;
+  padding-left: 2px;
+  padding-right: 2px;
+  margin-left: 5px;
   color: #C0392B;
 }
 

--- a/app/views/partials/_feed.erb
+++ b/app/views/partials/_feed.erb
@@ -3,7 +3,7 @@
     <div class="span7 feed-title-container">
       <p class="feed-title">
         <i class="icon-circle status <%= feed.status_bubble %>" data-toggle="tooltip" title="<%= t("partials.feed.status_bubble.#{feed.status_bubble}") if feed.status_bubble %>" data-placement="left"></i>
-        <a href="<%= feed.url %>"><%= feed.name %></a>
+        <%= feed.name %>
       </p>
     </div>
     <div class="span4 feed-last-updated">
@@ -16,8 +16,15 @@
         <% end %>
       </span>
     </div>
-    <div class="span1 remove-feed">
-      <a class="icon-remove"></a>
+    <div class="span1">
+      <span class="feed-url-link">
+        <a class="feed-url" href="<%= feed.url %>" target="_blank">
+          <i class="icon-external-link"></i>
+        </a>
+      </span>
+      <span class="remove-feed">
+        <a class="icon-remove"></a>
+      <span/>
     </div>
   </div>
 </li>


### PR DESCRIPTION
On feed list page:
- remove link from feed name
- add link with external link symbol left of removal link, link will be opened in new tab

This makes the external links more consistent (feed links then behave and look the same like the feed item permalink). And the Feed name is free for internal linking (maybe list of all feed items for the particular feed)
