### PR TITLE
StoriesController - Enforce Boolean type on #is_read and #keep_unread

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -16,10 +16,9 @@ class Stringer < Sinatra::Base
 
   put "/stories/:id" do
     json_params = JSON.parse(request.body.read, symbolize_names: true)
-    
     story = StoryRepository.fetch(params[:id])
-    story.is_read = json_params[:is_read]
-    story.keep_unread = json_params[:keep_unread]
+    story.is_read = !!json_params[:is_read]
+    story.keep_unread = !!json_params[:keep_unread]
     StoryRepository.save(story)
   end
 

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -73,13 +73,44 @@ describe "StoriesController" do
 
   describe "PUT /stories/:id" do
     before { StoryRepository.stub(:fetch).and_return(story_one) }
+    context "is_read parameter" do
+      context "when it is not malformed" do
+        it "marks a story as read" do
+          StoryRepository.should_receive(:save).once
 
-    it "marks a story as read" do
-      StoryRepository.should_receive(:save).once
+          put "/stories/#{story_one.id}", {is_read: true}.to_json
 
-      put "/stories/#{story_one.id}", {is_read: true}.to_json
+          story_one.is_read.should eq true
+        end
+      end
 
-      story_one.is_read.should be_true
+      context "when it is malformed" do
+        it "marks a story as read" do
+          StoryRepository.should_receive(:save).once
+
+          put "/stories/#{story_one.id}", {is_read: "malformed"}.to_json
+
+          story_one.is_read.should eq true
+        end
+      end
+    end
+
+    context "keep_unread parameter" do
+      context "when it is not malformed" do
+        it "marks a story as permanently unread" do
+          put "/stories/#{story_one.id}", {keep_unread: true}.to_json
+
+          story_one.keep_unread.should eq true
+        end
+      end
+
+      context "when it is malformed" do
+        it "marks a story as permanently unread" do
+          put "/stories/#{story_one.id}", {keep_unread: "malformed"}.to_json
+
+          story_one.keep_unread.should eq true
+        end
+      end
     end
   end
 


### PR DESCRIPTION
First of all, this prevents that we save user input data into
these two fields.
Second of all, I have refactored the test from "be true" to "eq true"
to prevent making assertions on 'truthful' objects (everything else
other than false and nil)
