### PR TITLE
add story listing for single feeds

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -8,6 +8,13 @@ class Stringer < Sinatra::Base
     erb :index
   end
 
+  get "/news/:feed_id" do
+    @unread_stories = StoryRepository.unread_by_feed_id(params[:feed_id])
+    @feed_id = params[:feed_id]
+
+    erb :index
+  end
+
   get "/archive" do
     @read_stories = StoryRepository.read(params[:page])
 
@@ -16,17 +23,21 @@ class Stringer < Sinatra::Base
 
   put "/stories/:id" do
     json_params = JSON.parse(request.body.read, symbolize_names: true)
-    
+
     story = StoryRepository.fetch(params[:id])
     story.is_read = !!json_params[:is_read]
     story.keep_unread = !!json_params[:keep_unread]
-    
+
     StoryRepository.save(story)
   end
 
   post "/mark_all_as_read" do
     MarkAllAsRead.new(params[:story_ids]).mark_as_read
-    
-    redirect to("/news")
+
+    if params[:feed_id]
+      redirect to("/news/#{params[:feed_id]}")
+    else
+      redirect to("/news")
+    end
   end
 end

--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -27,6 +27,10 @@ class StoryRepository
     Story.where(is_read: false).order("published desc") 
   end
 
+  def self.unread_by_feed_id(feed_id)
+    unread.where(feed_id: feed_id)
+  end
+
   def self.read(page = 1)
     Story.where(is_read: true).order("published desc").page(page).per_page(15)
   end
@@ -37,7 +41,7 @@ class StoryRepository
 
   def self.extract_content(entry)
     sanitized_content = ""
-    
+
     if entry.content
       sanitized_content = entry.content.sanitize
     elsif entry.summary

--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -5,14 +5,14 @@
 <% end %>
 
 <div id="action-bar">
-  <%= render_partial :action_bar, { stories: @unread_stories } %>
+  <%= render_partial :action_bar, { stories: @unread_stories, feed_id: @feed_id } %>
 </div>
 
 <% if @unread_stories.empty? %>
   <%= render_partial :zen %>
 <% else %>
   <%= render_js :stories, { stories: @unread_stories } %>
-  
+
   <div id="stories">
     <ul id="story-list">
     </ul>

--- a/app/views/partials/_action_bar.erb
+++ b/app/views/partials/_action_bar.erb
@@ -1,11 +1,14 @@
 <div class="row-fluid">
   <div class="pull-left">
+    <a class="btn" id="back-to-feeds" href="/feeds" title="<%= t('partials.action_bar.view_feeds') %>">
+      <i class="icon-reply"></i>
+    </a>
     <a class="btn" id="mark-all" title="<%= t('partials.action_bar.mark_all') %>">
       <i class="icon-ok"></i>
       <%= render_partial :mark_all_as_read_form,
-                        {stories: stories} %>
+                        {stories: stories, feed_id: feed_id} %>
     </a>
-    <a class="btn" href="/" id="refresh" title="<%= t('partials.action_bar.refresh') %>">
+    <a class="btn" href="/news<%= @feed_id ? ('/' + @feed_id) : '' %>" id="refresh" title="<%= t('partials.action_bar.refresh') %>">
       <i class="icon-repeat"></i>
     </a>
   </div>

--- a/app/views/partials/_feed.erb
+++ b/app/views/partials/_feed.erb
@@ -3,7 +3,7 @@
     <div class="span7 feed-title-container">
       <p class="feed-title">
         <i class="icon-circle status <%= feed.status_bubble %>" data-toggle="tooltip" title="<%= t("partials.feed.status_bubble.#{feed.status_bubble}") if feed.status_bubble %>" data-placement="left"></i>
-        <%= feed.name %>
+        <a href="news/<%= feed.id %>"><%= feed.name %></a>
         <span class="feed-url-link">
           <a class="feed-url" href="<%= feed.url %>">
             <i class="icon-external-link"></i>

--- a/app/views/partials/_mark_all_as_read_form.erb
+++ b/app/views/partials/_mark_all_as_read_form.erb
@@ -2,6 +2,7 @@
   <form id="mark-all-as-read" method="POST" action="/mark_all_as_read">
     <% stories.each do |story| %>
       <input type="hidden" name="story_ids[]" value="<%= story.id %>" />
+      <input type="hidden" name="feed_id" value="<%= feed_id %>" />
     <% end %>
   </form>
 </div>

--- a/app/views/partials/_tutorial_action_bar.erb
+++ b/app/views/partials/_tutorial_action_bar.erb
@@ -3,7 +3,7 @@
     <a class="btn" id="mark-all" title="<%= t('partials.action_bar.mark_all') %>">
       <i class="icon-ok"></i>
       <%= render_partial :mark_all_as_read_form,
-                        {stories: stories} %>
+                        {stories: stories, feed_id: nil} %>
     </a>
     <a class="btn" href="/" id="refresh" title="<%= t('partials.action_bar.refresh') %>">
       <i class="icon-repeat"></i>

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -123,5 +123,14 @@ describe "StoriesController" do
       last_response.status.should be 302
       URI::parse(last_response.location).path.should eq "/news"
     end
+
+    it "marks all unread stories of a feed as read and reload the page" do
+      MarkAllAsRead.any_instance.should_receive(:mark_as_read).once
+
+      post "/mark_all_as_read", story_ids: ["1", "2", "3"], feed_id: 4
+
+      last_response.status.should be 302
+      URI::parse(last_response.location).path.should eq "/news/4"
+    end
   end
 end


### PR DESCRIPTION
A click on the feed name in the feed listing will show the unread stories of the feed (or the zen page if zero). The "mark all as read" button works for the feeds stories. An additional (and duplicate!? "home" button links back to the feed listing). The refresh button is adjusted as well.
- the url for the feeds stories is "/news/:id" this may be change to "/feeds/:id/stories" or "/feeds/:id/news"
- I'm not 100% happy about the conditionals in the view and controller regarding whether a feed_id is given or not.  
