### PR TITLE
Make `heroku run console` do the right thing.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
+console: bundle exec racksh


### PR DESCRIPTION
```
>>> heroku run console
Running `console` attached to terminal... up, run.6679
** Building /js/application.js...
** Building /css/application.css...
Rack::Shell v1.0.0 started in production environment.
[1] pry(main)> Story.count
D, [2013-05-23T12:03:55.530118 #2] DEBUG -- :    (1.9ms)  SELECT COUNT(*) FROM "stories"
=> 206
[2] pry(main)>
```

Old habits die hard...
