### PR TITLE
Fixed Fever API implementation (fix #156)

### DIFF
--- a/app/commands/stories/mark_all_as_read.rb
+++ b/app/commands/stories/mark_all_as_read.rb
@@ -10,3 +10,4 @@ class MarkAllAsRead
     @repo.fetch_by_ids(@story_ids).update_all(is_read: true)
   end
 end
+

--- a/app/commands/stories/mark_as_read.rb
+++ b/app/commands/stories/mark_as_read.rb
@@ -1,0 +1,13 @@
+require_relative "../../repositories/story_repository"
+
+class MarkAsRead
+  def initialize(story_id, repository = StoryRepository)
+    @story_id = story_id
+    @repo = repository
+  end
+
+  def mark_as_read
+    @repo.fetch(@story_id).update_attributes(is_read: true)
+  end
+end
+

--- a/app/commands/stories/mark_as_unread.rb
+++ b/app/commands/stories/mark_as_unread.rb
@@ -1,0 +1,14 @@
+require_relative "../../repositories/story_repository"
+
+class MarkAsUnread
+  def initialize(story_id, repository = StoryRepository)
+    @story_id = story_id
+    @repo = repository
+  end
+
+  def mark_as_unread
+    @repo.fetch(@story_id).update_attributes(is_read: false)
+  end
+end
+
+

--- a/app/repositories/feed_repository.rb
+++ b/app/repositories/feed_repository.rb
@@ -21,3 +21,4 @@ class FeedRepository
     Feed.order('lower(name)')
   end
 end
+

--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -3,8 +3,8 @@ require_relative "../utils/sample_story"
 
 class StoryRepository
   def self.add(entry, feed)
-    Story.create(feed: feed, 
-                title: entry.title, 
+    Story.create(feed: feed,
+                title: entry.title,
                 permalink: entry.url,
                 body: extract_content(entry),
                 is_read: false,
@@ -24,7 +24,11 @@ class StoryRepository
   end
 
   def self.unread
-    Story.where(is_read: false).order("published desc") 
+    Story.where(is_read: false).order("published desc")
+  end
+
+  def self.unread_since_id(since_id)
+    unread.where('id > ?', since_id)
   end
 
   def self.read(page = 1)
@@ -37,7 +41,7 @@ class StoryRepository
 
   def self.extract_content(entry)
     sanitized_content = ""
-    
+
     if entry.content
       sanitized_content = entry.content.sanitize
     elsif entry.summary
@@ -71,3 +75,4 @@ class StoryRepository
     ]
   end
 end
+

--- a/spec/commands/stories/mark_as_read_spec.rb
+++ b/spec/commands/stories/mark_as_read_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+app_require "commands/stories/mark_as_read"
+
+describe MarkAsRead do
+  describe "#mark_as_read" do
+    let(:story) { stub }
+    let(:repo){ stub(fetch: story) }
+
+    it "marks a story as read" do
+      command = MarkAsRead.new(1, repo)
+      story.should_receive(:update_attributes).with(is_read: true)
+      command.mark_as_read
+    end
+  end
+end
+

--- a/spec/commands/stories/mark_as_unread_spec.rb
+++ b/spec/commands/stories/mark_as_unread_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+app_require "commands/stories/mark_as_unread"
+
+describe MarkAsUnread do
+  describe "#mark_as_unread" do
+    let(:story) { stub }
+    let(:repo){ stub(fetch: story) }
+
+    it "marks a story as read" do
+      command = MarkAsUnread.new(1, repo)
+      story.should_receive(:update_attributes).with(is_read: false)
+      command.mark_as_unread
+    end
+  end
+end
+
+


### PR DESCRIPTION
- Command "saved_item_ids" must return a CSV list of ids (not a JSON array)
- Command "unread_item_ids" must return a CSV list of ids (not a JSON array)
- Reeder app needs "since_id" support for the "items" command
- Implemented "mark" command for "item" ("read" and "unread")
