### PR TITLE
Open permalinks in new tabs

### DIFF
--- a/app/views/js/templates/_story.js.erb
+++ b/app/views/js/templates/_story.js.erb
@@ -38,7 +38,7 @@
         <div class="story-starred">
           <i class="icon-star{{ if(!is_starred) { }}-empty{{ } }}"></i>
         </div>
-        <a class="story-permalink" href="{{= permalink }}">
+        <a class="story-permalink" target="_blank" href="{{= permalink }}">
           <i class="icon-external-link"></i>
         </a>
       </div>


### PR DESCRIPTION
I know this is sort of a preference thing but the icon also implies that it opens in a new window. I like to keep my reader open even if I leave it to view a specific article.
