### PR TITLE
Use starred attribute in fever_json instead of fixed 0

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -35,7 +35,7 @@ class Story < ActiveRecord::Base
       author: source,
       html: body,
       url: self.permalink,
-      is_saved: 0,
+      is_saved: self.is_starred ? 1 : 0,
       is_read: self.is_read ? 1 : 0,
       created_on_time: self.published.to_i
     }


### PR DESCRIPTION
as_fever_json didn't consider the value of the starred-attribute of the story, instead it delivered 0 for every item:

> is_saved: 0
