### PR TITLE
Add GET /feeds/refresh for fetching feeds

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -52,4 +52,12 @@ class Stringer < Sinatra::Base
 
     ExportToOpml.new(Feed.all).to_xml
   end
+
+  get "/feeds/refresh" do
+    FetchFeeds.enqueue(Feed.all)
+  end
+
+  get "/feeds/:feed_id/refresh" do
+    FetchFeeds.enqueue(Feed.find(params[:feed_id]))
+  end
 end

--- a/spec/controllers/feeds_controller_spec.rb
+++ b/spec/controllers/feeds_controller_spec.rb
@@ -124,4 +124,25 @@ describe "FeedsController" do
       last_response.header["Content-Type"].should include 'xml'
     end
   end
+
+  describe "GET /feeds/refresh" do
+    it "Fetches all the feeds" do
+      Feed.stub(all: ['feed'])
+
+      FetchFeeds.should_receive(:enqueue).with(['feed'])
+
+      get "/feeds/refresh"
+    end
+  end
+
+  describe "GET /feeds/:feed_id/refresh" do
+    it "Fetches a feed given an id" do
+      feed_id = '123'
+
+      Feed.should_receive(:find).with(feed_id).and_return(['feed'])
+      FetchFeeds.should_receive(:enqueue).with(['feed'])
+
+      get "/feeds/#{feed_id}/refresh"
+    end
+  end
 end


### PR DESCRIPTION
A start to #33

This adds:
- `/feeds/refresh` for fetching all feeds
- `/feeds/:feed_id/refresh` for fetching a feed given an id

Thoughts?

I'm happy to change the verb to POST if you feel strongly about it, but GET made sense to me.
