### PR TITLE
Specify RACK_ENV=production in .bash_profile

### DIFF
--- a/VPS.md
+++ b/VPS.md
@@ -73,6 +73,7 @@ Stringer uses environment variables to determine information about your database
     echo 'export STRINGER_DATABASE="stringer_live"' >> $HOME/.bash_profile
     echo 'export STRINGER_DATABASE_USERNAME="stringer"' >> $HOME/.bash_profile
     echo 'export STRINGER_DATABASE_PASSWORD="EDIT_ME"' >> $HOME/.bash_profile
+    echo 'export RACK_ENV="production"' >> $HOME/.bash_profile
     source ~/.bash_profile
     
 Tell stringer to run the database in production mode, using the postgres database you created earlier.


### PR DESCRIPTION
Otherwise, when you run `bundle exec foreman start`, you would get:

20:01:43 web.1     | rake aborted!
20:01:43 web.1     | SQLite3::SQLException: no such table: delayed_jobs: UPDATE 
"delayed_jobs" SET "locked_by" = NULL, "locked_at" = NULL WHERE "delayed_jobs"."
locked_by" = 'host:us1 pid:5179'

...indicating that we are not in production env, and it is using the sqlite database.
