### PR TITLE
ActiveRecord::StatementInvalid - PG::Error: ERROR:  prepared statement "a1" already exists

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -18,7 +18,7 @@ end
 after_fork do |server, worker|
   if defined?(ActiveRecord::Base)
     env = ENV['RACK_ENV'] || "development"
-    config = YAML::load(File.open('config/database.yml'))[env]
+    config = YAML::load(ERB.new(File.read('config/database.yml')).result)[env]
     ActiveRecord::Base.establish_connection(config)
   end
 end


### PR DESCRIPTION
This seems to be the exact same problem as #171, but I get the same error on /news, whereas @grigio gets it only on /feeds/new.

Stringer was running in production mode and is using a pg db.  Any ideas?  Thanks!

```
21:45:32 web.1     | 69.136.248.30 - - [04/Jun/2013 21:45:32] "GET /news HTTP/1.0" 200 4820 0.0131
21:45:34 web.1     | D, [2013-06-04T21:45:34.891486 #1570] DEBUG -- :   User Load (0.7ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT 1  [["id", 1]]
21:45:34 web.1     | D, [2013-06-04T21:45:34.891629 #1570] DEBUG -- : PG::Error: ERROR:  prepared statement "a1" already exists
21:45:34 web.1     | : SELECT  "users".* FROM "users"  WHERE "users"."id" = $1 LIMIT 1
21:45:34 web.1     | ActiveRecord::StatementInvalid - PG::Error: ERROR:  prepared statement "a1" already exists
21:45:34 web.1     | : SELECT  "users".* FROM "users"  WHERE "users"."id" = $1 LIMIT 1:
21:45:34 web.1     |    /home/stringer/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/postgresql_adapter.rb:1194:in `prepare
'
21:45:34 web.1     |    /home/stringer/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/postgresql_adapter.rb:1194:in `prepare
_statement'
21:45:34 web.1     |    /home/stringer/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/postgresql_adapter.rb:1158:in `exec_ca
che'
21:45:34 web.1     |    /home/stringer/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/postgresql_adapter.rb:663:in `block in
 exec_query'
21:45:34 web.1     |    /home/stringer/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_adapter.rb:280:in `block in l
og'
21:45:34 web.1     |    /home/stringer/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/activesupport-3.2.12/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
21:45:34 web.1     |    /home/stringer/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract_adapter.rb:275:in `log'
21:45:34 web.1     |    /home/stringer/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/postgresql_adapter.rb:661:in `exec_que
ry'
21:45:34 web.1     |    /home/stringer/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/postgresql_adapter.rb:1248:in `select'
21:45:34 web.1     |    /home/stringer/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/activerecord-3.2.12/lib/active_record/connection_adapters/abstract/database_statements.rb:18:in 
`select_all'

```
