### PR TITLE
config: add STRINGER_DATABASE_{HOST,PORT}

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -13,3 +13,5 @@ production:
   database: <%= ENV['STRINGER_DATABASE'] || "stringer" %>
   username: <%= ENV['STRINGER_DATABASE_USERNAME'] %>
   password: <%= ENV['STRINGER_DATABASE_PASSWORD'] %>
+  host: <%= ENV['STRINGER_DATABASE_HOST'] %>
+  port: <%= ENV['STRINGER_DATABASE_PORT'] %>


### PR DESCRIPTION
If STRINGER_DATABASE_HOST is set, Stringer uses specified socket rather than default Unix domain socket.
STRINGER_DATABASE_PORT can also be used if custom port is used.
