### PR TITLE
Fixed expanding absolute urls

### DIFF
--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -65,7 +65,7 @@ class StoryRepository
     [["a", "href"], ["img", "src"], ["video", "src"]].each do |tag, attr|
       doc.css(tag).each do |node|
         url = node.get_attribute(attr)
-        unless url =~ abs_re
+        unless url =~ abs_re || url.nil?
           node.set_attribute(attr, URI.join(base_url, url).to_s)
         end
       end

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -33,6 +33,25 @@ describe StoryRepository do
     it "handles empty body" do
       StoryRepository.expand_absolute_urls("", nil).should eq ""
     end
+
+    it "doesn't modify tags that do not have url attributes" do
+      content = <<-EOS
+<div>
+<img foo="bar">
+<a name="something"/></a>
+<video foo="bar"></video>
+</div>
+      EOS
+
+      result = StoryRepository.expand_absolute_urls(content, "http://oodl.io/d/")
+      result.gsub(/\n/, "").should eq <<-EOS.gsub(/\n/, "")
+<div>
+<img foo="bar">
+<a name="something"></a>
+<video foo="bar"></video>
+</div>
+      EOS
+    end
   end
 
   describe ".extract_content" do


### PR DESCRIPTION
`StoryRepository.expand_absolute_urls` crashes on line 69 (trying to build the absolute url) when the tag being modified doesn't contain url attribute. One example of such tag could be anchor `<a/>` tag. This commit fixes that issue.

You can see example of a feed that was failing to parse because of this bug at http://dee-kup.livejournal.com/data/rss
