### PR TITLE
Prevent n+1 queries when serializing stories to json

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -30,7 +30,7 @@ class Story < ActiveRecord::Base
   def as_fever_json
     {
       id: self.id,
-      feed_id: self.feed.id,
+      feed_id: self.feed_id,
       title: self.title,
       author: source,
       html: body,

--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -25,7 +25,7 @@ class StoryRepository
   end
 
   def self.unread
-    Story.where(is_read: false).order("published desc")
+    Story.where(is_read: false).order("published desc").includes(:feed)
   end
 
   def self.unread_since_id(since_id)
@@ -33,12 +33,12 @@ class StoryRepository
   end
 
   def self.read(page = 1)
-    Story.where(is_read: true)
+    Story.where(is_read: true).includes(:feed)
       .order("published desc").page(page).per_page(20)
   end
 
   def self.starred(page = 1)
-    Story.where(is_starred: true)
+    Story.where(is_starred: true).includes(:feed)
           .order("published desc").page(page).per_page(20)
   end
 


### PR DESCRIPTION
If you watch the logs when loading pages like /news, /archives or /starred, you'll see that we're fetching the feed for each story displayed one at a time.

This should prevent so many queries from being run by eagerly loading the feed associated and using `feed_id` rather than `feed.id` so we don't have to load the feed object just for the ID.
