### PR TITLE
Use threadsafe version of feedbag.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "will_paginate"
 gem "feedzirra", github: "swanson/feedzirra"
 gem "loofah"
 gem "nokogiri"
-gem "feedbag", github: "dwillis/feedbag"
+gem "feedbag", github: "mje113/feedbag"
 gem "highline", require: false
 gem "thread"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: git://github.com/dwillis/feedbag.git
-  revision: f7f2269ada54f9b5be7c1312949512bb8a557b10
+  remote: git://github.com/mje113/feedbag.git
+  revision: 7958a46fe424ee81198669b1ebc9db52fb4d4549
   specs:
     feedbag (0.9.1)
       nokogiri


### PR DESCRIPTION
I was digging into stringer (awesome project) and dwillis/feedbag and saw that it's got a pretty major thread-safety issue.  I propose using my patch until it gets merged upstream.
