### PR TITLE
Allow groups in fever to be marked as read

### DIFF
--- a/app/commands/stories/mark_group_as_read.rb
+++ b/app/commands/stories/mark_group_as_read.rb
@@ -1,0 +1,14 @@
+require_relative "../../repositories/story_repository"
+
+class MarkGroupAsRead
+  def initialize(group_id, timestamp, repository = StoryRepository)
+    @group_id  = group_id.to_i
+    @repo      = repository
+    @timestamp = timestamp
+  end
+
+  def mark_group_as_read
+    @repo.fetch_unread_by_timestamp(@timestamp).update_all(is_read: true) if @group_id == 1
+  end
+end
+

--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -20,6 +20,11 @@ class StoryRepository
     Story.where(id: ids)
   end
 
+  def self.fetch_unread_by_timestamp(timestamp)
+    timestamp = Time.at(timestamp.to_i)
+    Story.where("created_at < ? AND is_read = ?", timestamp, false)
+  end
+
   def self.save(story)
     story.save
   end

--- a/fever_api.rb
+++ b/fever_api.rb
@@ -10,6 +10,7 @@ require_relative "app/commands/stories/mark_as_unread"
 
 require_relative "app/commands/stories/mark_as_starred"
 require_relative "app/commands/stories/mark_as_unstarred"
+require_relative "app/commands/stories/mark_group_as_read"
 
 class FeverAPI < Sinatra::Base
   configure do
@@ -68,7 +69,7 @@ class FeverAPI < Sinatra::Base
     if keys.include?(:items)
       if keys.include?(:with_ids)
         response[:items] = stories_by_ids(params[:with_ids].split(",")).map{|s| s.as_fever_json}
-        response[:total_items] = stories_by_ids(params[:with_ids].split(",")).count  
+        response[:total_items] = stories_by_ids(params[:with_ids].split(",")).count
       else
         response[:items] = unread_stories(params[:since_id]).map{|s| s.as_fever_json}
         response[:total_items] = unread_stories.count
@@ -98,6 +99,8 @@ class FeverAPI < Sinatra::Base
       when "unsaved"
         MarkAsUnstarred.new(params[:id]).mark_as_unstarred
       end
+    elsif params[:mark] == "group"
+      MarkGroupAsRead.new(params[:id], params[:before]).mark_group_as_read
     end
 
     response.to_json

--- a/spec/commands/stories/mark_group_as_read_spec.rb
+++ b/spec/commands/stories/mark_group_as_read_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+app_require "commands/stories/mark_group_as_read"
+
+describe MarkGroupAsRead do
+  describe "#mark_group_as_read" do
+    let(:stories) { stub }
+    let(:repo){ stub(fetch_unread_by_timestamp: stories) }
+
+    it "marks group 1 as read" do
+      command = MarkGroupAsRead.new(1, Time.now.to_i, repo)
+      stories.should_receive(:update_all).with(is_read: true)
+      command.mark_group_as_read
+    end
+
+    it "odes not mark other groups as read" do
+      command = MarkGroupAsRead.new(2, Time.now.to_i, repo)
+      stories.should_not_receive(:update_all).with(is_read: true)
+      command.mark_group_as_read
+    end
+  end
+end


### PR DESCRIPTION
Marks group one (everything) as read in the fever API

Close #217
