### PR TITLE
Ignore case comparing fever api_key

### DIFF
--- a/fever_api.rb
+++ b/fever_api.rb
@@ -25,7 +25,7 @@ class FeverAPI < Sinatra::Base
 
   def authenticated?(api_key)
     user = User.first
-    user.api_key && api_key == user.api_key
+    user.api_key && api_key.downcase == user.api_key.downcase
   end
 
   get "/" do


### PR DESCRIPTION
some clients (at least mr.reader on iOS) use upper case characters.
