### PR TITLE
Use If-Modified-Since Header when refreshing feeds

### DIFF
--- a/app/tasks/fetch_feed.rb
+++ b/app/tasks/fetch_feed.rb
@@ -13,7 +13,7 @@ class FetchFeed
 
   def fetch
     begin
-      raw_feed = @parser.fetch_and_parse(@feed.url, user_agent: "Stringer")
+      raw_feed = @parser.fetch_and_parse(@feed.url, user_agent: "Stringer", if_modified_since: @feed.last_fetched)
 
       new_entries_from(raw_feed).each do |entry|
         StoryRepository.add(entry, @feed)


### PR DESCRIPTION
Fetch feeds with the If-Modified-Since HTTP header set to the last refresh timestamp.
This should save us (and the feed providers) quite some traffic since we don't have to fetch the whole feed when the content hasn't changed
