### PR TITLE
Little mistake in last-modified changes

### DIFF
--- a/app/tasks/fetch_feed.rb
+++ b/app/tasks/fetch_feed.rb
@@ -21,10 +21,10 @@ class FetchFeed
         new_entries_from(raw_feed).each do |entry|
           StoryRepository.add(entry, @feed)
         end
-      end
 
-      FeedRepository.update_last_fetched(@feed, raw_feed.last_modified)
-      FeedRepository.set_status(:green, @feed)
+        FeedRepository.update_last_fetched(@feed, raw_feed.last_modified)
+        FeedRepository.set_status(:green, @feed)
+      end
     rescue Exception => ex
       FeedRepository.set_status(:red, @feed)
 


### PR DESCRIPTION
We should only update the feed's last_fetched timestamp when we have actually fetched something.
