### PR TITLE
Don't fail if logger is not defined

### DIFF
--- a/app/tasks/fetch_feed.rb
+++ b/app/tasks/fetch_feed.rb
@@ -16,7 +16,7 @@ class FetchFeed
       raw_feed = @parser.fetch_and_parse(@feed.url, user_agent: "Stringer", if_modified_since: @feed.last_fetched)
 
       if raw_feed == 304
-        @logger.info "Feed has not been modified since last fetch"
+        @logger.info "Feed has not been modified since last fetch" if @logger
       else
         new_entries_from(raw_feed).each do |entry|
           StoryRepository.add(entry, @feed)


### PR DESCRIPTION
Introduced in a recent commit, a feed would be marked as "failed" if the logger is not defined (nil) when the feed content hasn't changed (304 Not Modified).
