### PR TITLE
Set feed status to green when parsing feeds returns 304

### DIFF
--- a/app/tasks/fetch_feed.rb
+++ b/app/tasks/fetch_feed.rb
@@ -23,8 +23,9 @@ class FetchFeed
         end
 
         FeedRepository.update_last_fetched(@feed, raw_feed.last_modified)
-        FeedRepository.set_status(:green, @feed)
       end
+
+      FeedRepository.set_status(:green, @feed)
     rescue Exception => ex
       FeedRepository.set_status(:red, @feed)
 


### PR DESCRIPTION
Correctly stets the feed status as described in #232.
