### PR TITLE
Make export feeds serve a file

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -48,7 +48,8 @@ class Stringer < Sinatra::Base
   end
 
   get "/feeds/export" do
-    content_type :xml
+    content_type 'application/octet-stream'
+    attachment 'stringer.xml'
 
     ExportToOpml.new(Feed.all).to_xml
   end

--- a/spec/controllers/feeds_controller_spec.rb
+++ b/spec/controllers/feeds_controller_spec.rb
@@ -117,11 +117,12 @@ describe "FeedsController" do
 
     it "returns an OPML file" do
       ExportToOpml.any_instance.should_receive(:to_xml).and_return(some_xml)
-    
+
       get "/feeds/export"
 
       last_response.body.should eq some_xml
-      last_response.header["Content-Type"].should include 'xml'
+      last_response.header["Content-Type"].should include 'application/octet-stream'
+      last_response.header["Content-Disposition"].should == "attachment; filename=\"stringer.xml\""
     end
   end
 end


### PR DESCRIPTION
This change forces a file to be downloaded instead of displaying the feed XML onscreen.
