### PR TITLE
Use .opml as file extension when exporting OPML

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -48,7 +48,7 @@ class Stringer < Sinatra::Base
   end
 
   get "/feeds/export" do
-    content_type 'application/octet-stream'
+    content_type 'application/xml'
     attachment 'stringer.opml'
 
     ExportToOpml.new(Feed.all).to_xml

--- a/spec/controllers/feeds_controller_spec.rb
+++ b/spec/controllers/feeds_controller_spec.rb
@@ -121,7 +121,7 @@ describe "FeedsController" do
       get "/feeds/export"
 
       last_response.body.should eq some_xml
-      last_response.header["Content-Type"].should include 'application/octet-stream'
+      last_response.header["Content-Type"].should include 'application/xml'
       last_response.header["Content-Disposition"].should == "attachment; filename=\"stringer.opml\""
     end
   end


### PR DESCRIPTION
I would argue that it's better to use the more specific `.opml` file extension over just `.xml` when exporting feeds as OPML. I believe this is the same behavior as was found in `BIG_FREE_READER`.
