### PR TITLE
undefined method `downcase' for nil:NilClass in FeverAPI

### DIFF
--- a/fever_api.rb
+++ b/fever_api.rb
@@ -21,12 +21,14 @@ class FeverAPI < Sinatra::Base
   end
 
   before do
-    halt 403 if !params[:api_key] || !authenticated?(params[:api_key])
+    halt 403 unless authenticated?(params[:api_key])
   end
 
   def authenticated?(api_key)
-    user = User.first
-    user.api_key && api_key.downcase == user.api_key.downcase
+    if api_key
+      user = User.first
+      user.api_key && api_key.downcase == user.api_key.downcase
+    end
   end
 
   get "/" do


### PR DESCRIPTION
I've noticed that every time when Reeder for iPhone sends requests to stringer server, it sends first request without `api_key`. In logs it looks like the following (I put `ap params` in `before` block):

``` logs
10:22:10 web.1     | I, [2013-07-25T10:22:10.222675 #30539]  INFO -- : worker=2 ready
10:22:11 web.1     | {
10:22:11 web.1     |     "refresh" => nil
10:22:11 web.1     | }
10:22:11 web.1     | D, [2013-07-25T10:22:11.306222 #30539] DEBUG -- :   User Load (0.1ms)  SELECT "users".* FROM "users" LIMIT 1
10:22:11 web.1     | NoMethodError - undefined method `downcase' for nil:NilClass:
10:22:11 web.1     |    /Users/fabian/ruby/stringer/master/fever_api.rb:30:in `authenticated?'
10:22:11 web.1     |    /Users/fabian/ruby/stringer/master/fever_api.rb:25:in `block in <class:FeverAPI>'
< skipped full trace >
10:22:11 web.1     | 192.168.21.29 - - [25/Jul/2013 10:22:11] "GET /fever/?refresh HTTP/1.1" 500 154858 0.1537
10:22:11 web.1     | {
10:22:11 web.1     |                 "api" => nil,
10:22:11 web.1     |     "unread_item_ids" => nil,
10:22:11 web.1     |             "api_key" => "6c10192689bf2c84a88d7937fbcf26f6"
10:22:11 web.1     | }
```
