### PR TITLE
A simple and quick way to have feed groups in fever clients.

### DIFF
--- a/app/commands/feeds/import_from_opml.rb
+++ b/app/commands/feeds/import_from_opml.rb
@@ -1,16 +1,35 @@
 require_relative "../../models/feed"
+require_relative "../../models/group"
 require_relative "../../utils/opml_parser"
 
 class ImportFromOpml
   ONE_DAY = 24 * 60 * 60
 
-  def self.import(opml_contents)
-    feeds = OpmlParser.new.parse_feeds(opml_contents)
+  class << self
+    def import(opml_contents)
+      feeds_with_groups = OpmlParser.new.parse_feeds(opml_contents)
 
-    feeds.each do |feed|
-      Feed.create(name: feed[:name],
-                  url: feed[:url],
-                  last_fetched: Time.now - ONE_DAY)
+      # It considers a situation when feeds are already imported without groups,
+      # so it's possible to re-import the same subscriptions.xml just to set group_id
+      # for existing feeds. Feeds without groups are in 'Ungrouped' group, we don't
+      # create such group and create such feeds with group_id = nil.
+      #
+      feeds_with_groups.each do |group_name, parsed_feeds|
+        if parsed_feeds.size > 0
+          group = Group.where(name: group_name).first_or_create unless group_name == 'Ungrouped'
+
+          parsed_feeds.each { |parsed_feed| create_feed(parsed_feed, group) }
+        end
+      end
+    end
+
+    private
+
+    def create_feed(parsed_feed, group)
+      feed = Feed.where(name: parsed_feed[:name], url: parsed_feed[:url]).first_or_initialize
+      feed.last_fetched = Time.now - ONE_DAY if feed.new_record?
+      feed.group_id = group.id if group
+      feed.save
     end
   end
 end

--- a/app/commands/stories/mark_group_as_read.rb
+++ b/app/commands/stories/mark_group_as_read.rb
@@ -1,18 +1,22 @@
 require_relative "../../repositories/story_repository"
 
 class MarkGroupAsRead
-  KINDLING_GROUP_ID            = 1
-  SPARKS_AND_KINDLING_GROUP_ID = 0
+  KINDLING_GROUP_ID = 0
+  SPARKS_GROUP_ID   = -1
 
   def initialize(group_id, timestamp, repository = StoryRepository)
-    @group_id  = group_id.to_i
+    @group_id  = group_id
     @repo      = repository
     @timestamp = timestamp
   end
 
   def mark_group_as_read
-    if [SPARKS_AND_KINDLING_GROUP_ID, KINDLING_GROUP_ID].include? @group_id
+    return unless @group_id
+
+    if [KINDLING_GROUP_ID, SPARKS_GROUP_ID].include?(@group_id.to_i)
       @repo.fetch_unread_by_timestamp(@timestamp).update_all(is_read: true)
+    elsif @group_id.to_i > 0
+      @repo.fetch_unread_by_timestamp_and_group(@timestamp, @group_id).update_all(is_read: true)
     end
   end
 end

--- a/app/fever_api/read_feeds_groups.rb
+++ b/app/fever_api/read_feeds_groups.rb
@@ -17,16 +17,12 @@ module FeverAPI
     private
 
     def feeds_groups
-      [
+      @feed_repository.in_group.order('LOWER(name)').group_by(&:group_id).map do |group_id, feeds|
         {
-          group_id: 1,
-          feed_ids: feeds.map{|f| f.id}.join(",")
+          group_id: group_id,
+          feed_ids: feeds.map(&:id).join(',')
         }
-      ]
-    end
-
-    def feeds
-      @feed_repository.list
+      end
     end
   end
 end

--- a/app/fever_api/read_groups.rb
+++ b/app/fever_api/read_groups.rb
@@ -1,5 +1,11 @@
+require_relative "../repositories/group_repository"
+
 module FeverAPI
   class ReadGroups
+    def initialize(options = {})
+      @group_repository = options.fetch(:group_repository){ GroupRepository }
+    end
+
     def call(params = {})
       if params.keys.include?('groups')
         { groups: groups }
@@ -11,12 +17,7 @@ module FeverAPI
     private
 
     def groups
-      [
-        {
-          id: 1,
-          title: "All items"
-        }
-      ]
+      @group_repository.list.map(&:as_fever_json)
     end
   end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -1,5 +1,6 @@
 class Feed < ActiveRecord::Base
   has_many :stories, -> {order "published desc"} , dependent: :delete_all
+  belongs_to :group
 
   validates_uniqueness_of :url
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,7 @@
+class Group < ActiveRecord::Base
+  has_many :feeds
+
+  def as_fever_json
+    { id: self.id, title: self.name }
+  end
+end

--- a/app/repositories/feed_repository.rb
+++ b/app/repositories/feed_repository.rb
@@ -31,6 +31,10 @@ class FeedRepository
     Feed.order('lower(name)')
   end
 
+  def self.in_group
+    Feed.where('group_id IS NOT NULL')
+  end
+
   private
 
   def self.valid_timestamp?(new_timestamp, current_timestamp)

--- a/app/repositories/group_repository.rb
+++ b/app/repositories/group_repository.rb
@@ -1,0 +1,7 @@
+require_relative "../models/group"
+
+class GroupRepository
+  def self.list
+    Group.order('LOWER(name)')
+  end
+end

--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -23,7 +23,11 @@ class StoryRepository
 
   def self.fetch_unread_by_timestamp(timestamp)
     timestamp = Time.at(timestamp.to_i)
-    Story.where("created_at < ? AND is_read = ?", timestamp, false)
+    Story.where('stories.created_at < ?', timestamp).where(is_read: false)
+  end
+
+  def self.fetch_unread_by_timestamp_and_group(timestamp, group_id)
+    fetch_unread_by_timestamp(timestamp).joins(:feed).where(feeds: { group_id: group_id })
   end
 
   def self.fetch_unread_for_feed_by_timestamp(feed_id, timestamp)

--- a/db/migrate/20140413100725_add_groups_table_and_foreign_keys_to_feeds.rb
+++ b/db/migrate/20140413100725_add_groups_table_and_foreign_keys_to_feeds.rb
@@ -1,0 +1,14 @@
+class AddGroupsTableAndForeignKeysToFeeds < ActiveRecord::Migration
+  def up
+    create_table :groups do |t|
+      t.string :name, null: false
+      t.timestamps null: false
+    end
+    add_column :feeds, :group_id, :integer
+  end
+
+  def down
+    drop_table :groups
+    remove_column :feeds, :group_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,9 +38,16 @@ ActiveRecord::Schema.define(version: 20140421224454) do
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
     t.integer  "status"
+    t.integer  "group_id"
   end
 
   add_index "feeds", ["url"], name: "index_feeds_on_url", unique: true, using: :btree
+
+  create_table "groups", force: true do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "stories", force: true do |t|
     t.text     "title"

--- a/spec/commands/feeds/add_new_feed_spec.rb
+++ b/spec/commands/feeds/add_new_feed_spec.rb
@@ -19,7 +19,7 @@ describe AddNewFeed do
       let(:discoverer) { double(discover: feed_result) }
       let(:feed) { FeedFactory.build }
       let(:repo) { double }
-      
+
       it "parses and creates the feed if discovered" do
         repo.should_receive(:create).and_return(feed)
 

--- a/spec/commands/feeds/import_from_opml_spec.rb
+++ b/spec/commands/feeds/import_from_opml_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+app_require "commands/feeds/import_from_opml"
+
+describe ImportFromOpml do
+  let(:subscriptions) { File.open(File.expand_path('../../../support/files/subscriptions.xml', __FILE__)) }
+
+  def import
+    described_class.import(subscriptions)
+  end
+
+  after do
+    Feed.delete_all
+    Group.delete_all
+  end
+
+  let(:group_1 ) { Group.find_by_name('Football News') }
+  let(:group_2 ) { Group.find_by_name('RoR') }
+
+  context 'adding group_id for existing feeds' do
+    let!(:feed_1) { Feed.create(name: 'TMW Football Transfer News',
+                                url: 'http://www.transfermarketweb.com/rss') }
+    let!(:feed_2) { Feed.create(name: 'GIANT ROBOTS SMASHING INTO OTHER GIANT ROBOTS - Home',
+                                url: 'http://feeds.feedburner.com/GiantRobotsSmashingIntoOtherGiantRobots') }
+    before { import }
+
+    it 'retains exising feeds' do
+      feed_1.should be_valid
+      feed_2.should be_valid
+    end
+
+    it 'creates new groups' do
+      group_1.should be
+      group_2.should be
+    end
+
+    it 'sets group_id for existing feeds' do
+      feed_1.reload.group.should eq group_1
+      feed_2.reload.group.should eq group_2
+    end
+  end
+
+  context 'creates new feeds with groups' do
+    let(:feed_1) { Feed.where(name: 'TMW Football Transfer News',
+                              url: 'http://www.transfermarketweb.com/rss') }
+
+    let(:feed_2) { Feed.where(name: 'GIANT ROBOTS SMASHING INTO OTHER GIANT ROBOTS - Home',
+                              url: 'http://feeds.feedburner.com/GiantRobotsSmashingIntoOtherGiantRobots') }
+    before { import }
+
+    it 'creates groups' do
+      group_1.should be
+      group_1.should be
+    end
+
+    it 'creates feeds' do
+      feed_1.should exist
+      feed_2.should exist
+    end
+
+    it 'sets group' do
+      feed_1.first.group.should eq group_1
+      feed_2.first.group.should eq group_2
+    end
+  end
+
+  context 'creates new feeds without group' do
+    let(:feed_1) { Feed.where(name: 'Autoblog', url: 'http://feeds.autoblog.com/weblogsinc/autoblog/').first }
+    let(:feed_2) { Feed.where(name: 'City Guide News', url: 'http://www.probki.net/news/RSS_news_feed.asp').first }
+
+    before { import }
+
+    it 'does not create any new group for feeds without group' do
+      Group.where('id NOT IN (?)', [group_1.id, group_2.id]).count.should eq 0
+    end
+
+    it 'creates feeds without group_id' do
+      feed_1.group_id.should be_nil
+      feed_2.group_id.should be_nil
+    end
+  end
+end

--- a/spec/commands/stories/mark_group_as_read_spec.rb
+++ b/spec/commands/stories/mark_group_as_read_spec.rb
@@ -3,26 +3,44 @@ require "spec_helper"
 app_require "commands/stories/mark_group_as_read"
 
 describe MarkGroupAsRead do
-  describe "#mark_group_as_read" do
+  describe '#mark_group_as_read' do
     let(:stories) { double }
-    let(:repo){ double(fetch_unread_by_timestamp: stories) }
+    let(:repo) { double }
+    let(:timestamp) { Time.now.to_i }
 
-    it "marks group 0 as read" do
-      command = MarkGroupAsRead.new(0, Time.now.to_i, repo)
+    def run_command(group_id)
+      MarkGroupAsRead.new(group_id, timestamp, repo)
+    end
+
+    it 'marks group as read' do
+      command = run_command(2)
       stories.should_receive(:update_all).with(is_read: true)
+      repo.should_receive(:fetch_unread_by_timestamp_and_group).with(timestamp, 2).and_return(stories)
       command.mark_group_as_read
     end
 
-    it "marks group 1 as read" do
-      command = MarkGroupAsRead.new(1, Time.now.to_i, repo)
-      stories.should_receive(:update_all).with(is_read: true)
+    it 'does not mark any group as read when group is not provided' do
+      command = run_command(nil)
+      repo.should_not_receive(:fetch_unread_by_timestamp_and_group)
+      repo.should_not_receive(:fetch_unread_by_timestamp)
       command.mark_group_as_read
     end
 
-    it "does not mark other groups as read" do
-      command = MarkGroupAsRead.new(2, Time.now.to_i, repo)
-      stories.should_not_receive(:update_all).with(is_read: true)
-      command.mark_group_as_read
+    context 'SPARKS_GROUP_ID and KINDLING_GROUP_ID' do
+      before do
+        stories.should_receive(:update_all).with(is_read: true)
+        repo.should_receive(:fetch_unread_by_timestamp).and_return(stories)
+      end
+
+      it 'marks as read all feeds when group is 0' do
+        command = run_command(0)
+        command.mark_group_as_read
+      end
+
+      it 'marks as read all feeds when group is -1' do
+        command = run_command(-1)
+        command.mark_group_as_read
+      end
     end
   end
 end

--- a/spec/factories/feed_factory.rb
+++ b/spec/factories/feed_factory.rb
@@ -16,6 +16,7 @@ class FeedFactory
   def self.build(params = {})
     FakeFeed.new(
       id: rand(100),
+      group_id: params[:group_id] || rand(100),
       name: params[:name] || Faker::Name.name + " on Software",
       url: params[:url] || Faker::Internet.url,
       last_fetched: params[:last_fetched] || Time.now,

--- a/spec/factories/group_factory.rb
+++ b/spec/factories/group_factory.rb
@@ -1,0 +1,16 @@
+class GroupFactory
+  class FakeGroup < OpenStruct
+    def as_fever_json
+      {
+        id: self.id,
+        title: self.name
+      }
+    end
+  end
+
+  def self.build(params = {})
+    FakeGroup.new(
+      id: rand(100),
+      name: params[:name] || Faker::Name.name + ' group')
+  end
+end

--- a/spec/fever_api/read_feeds_groups_spec.rb
+++ b/spec/fever_api/read_feeds_groups_spec.rb
@@ -4,7 +4,7 @@ app_require "fever_api/read_feeds_groups"
 
 describe FeverAPI::ReadFeedsGroups do
   let(:feed_ids) { [5, 7, 11] }
-  let(:feeds) { feed_ids.map{|id| double('feed', id: id) } }
+  let(:feeds) { feed_ids.map{|id| double('feed', id: id, group_id: 1) } }
   let(:feed_repository) { double('repo') }
 
   subject do
@@ -12,7 +12,8 @@ describe FeverAPI::ReadFeedsGroups do
   end
 
   it "returns a list of groups requested through feeds" do
-    feed_repository.should_receive(:list).and_return(feeds)
+    feed_repository.stub_chain(:in_group, :order).and_return(feeds)
+
     subject.call('feeds' => nil).should == {
       feeds_groups: [
         {
@@ -24,7 +25,8 @@ describe FeverAPI::ReadFeedsGroups do
   end
 
   it "returns a list of groups requested through groups" do
-    feed_repository.should_receive(:list).and_return(feeds)
+    feed_repository.stub_chain(:in_group, :order).and_return(feeds)
+
     subject.call('groups' => nil).should == {
       feeds_groups: [
         {

--- a/spec/fever_api/read_groups_spec.rb
+++ b/spec/fever_api/read_groups_spec.rb
@@ -3,14 +3,23 @@ require "spec_helper"
 app_require "fever_api/read_groups"
 
 describe FeverAPI::ReadGroups do
-  subject { FeverAPI::ReadGroups.new }
+  let(:group_1) { double('group_1', as_fever_json: { id: 1, title: 'IT news' }) }
+  let(:group_2) { double('group_2', as_fever_json: { id: 2, title: 'World news' }) }
+  let(:group_repository) { double('repo') }
 
-  it "returns a fixed group list if requested" do
+  subject { FeverAPI::ReadGroups.new(group_repository: group_repository) }
+
+  it "returns a group list if requested" do
+    group_repository.should_receive(:list).and_return([group_1, group_2])
     subject.call('groups' => nil).should == {
       groups: [
         {
           id: 1,
-          title: "All items"
+          title: "IT news"
+        },
+        {
+          id: 2,
+          title: 'World news'
         }
       ]
     }

--- a/spec/fever_api_spec.rb
+++ b/spec/fever_api_spec.rb
@@ -11,7 +11,8 @@ describe FeverAPI do
   let(:api_key) { 'apisecretkey' }
   let(:story_one) { StoryFactory.build }
   let(:story_two) { StoryFactory.build }
-  let(:feed) { FeedFactory.build }
+  let(:group) { GroupFactory.build }
+  let(:feed) { FeedFactory.build(group_id: group.id) }
   let(:stories) { [story_one, story_two] }
   let(:answer) { { api_version: 3, auth: 1, last_refreshed_on_time: Time.now.to_i } }
   let(:headers) { { api_key: api_key } }
@@ -50,25 +51,26 @@ describe FeverAPI do
     end
 
     it "returns groups and feeds by groups when 'groups' header is provided" do
-      FeedRepository.stub(:list).and_return([feed])
-      make_request({ groups: nil })
-      answer.merge!({ groups: [{ id: 1, title: "All items" }], feeds_groups: [{ group_id: 1, feed_ids: feed.id.to_s }] })
+      GroupRepository.stub(:list).and_return([group])
+      FeedRepository.stub_chain(:in_group, :order).and_return([feed])
+      make_request(groups: nil)
+      answer.merge!(groups: [group.as_fever_json], feeds_groups: [{ group_id: group.id, feed_ids: feed.id.to_s }])
       last_response.should be_ok
       last_response.body.should == answer.to_json
     end
 
     it "returns feeds and feeds by groups when 'feeds' header is provided" do
-      Feed.stub(:all).and_return([feed])
       FeedRepository.stub(:list).and_return([feed])
-      make_request({ feeds: nil })
-      answer.merge!({ feeds: [feed.as_fever_json], feeds_groups: [{ group_id: 1, feed_ids: feed.id.to_s }] })
+      FeedRepository.stub_chain(:in_group, :order).and_return([feed])
+      make_request(feeds: nil)
+      answer.merge!(feeds: [feed.as_fever_json], feeds_groups: [{ group_id: group.id, feed_ids: feed.id.to_s }])
       last_response.should be_ok
       last_response.body.should == answer.to_json
     end
 
     it "returns favicons hash when 'favicons' header provided" do
-      make_request({ favicons: nil })
-      answer.merge!({ favicons: [{ id: 0, data: "image/gif;base64,R0lGODlhAQABAIAAAObm5gAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" }] })
+      make_request(favicons: nil)
+      answer.merge!(favicons: [{ id: 0, data: "image/gif;base64,R0lGODlhAQABAIAAAObm5gAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" }])
       last_response.should be_ok
       last_response.body.should == answer.to_json
     end
@@ -76,47 +78,47 @@ describe FeverAPI do
     it "returns stories when 'items' header is provided along with 'since_id'" do
       StoryRepository.should_receive(:unread_since_id).with('5').and_return([story_one])
       StoryRepository.should_receive(:unread).and_return([story_one, story_two])
-      make_request({ items: nil, since_id: 5 })
-      answer.merge!({ items: [story_one.as_fever_json], total_items: 2 })
+      make_request(items: nil, since_id: 5)
+      answer.merge!(items: [story_one.as_fever_json], total_items: 2)
       last_response.should be_ok
       last_response.body.should == answer.to_json
     end
 
     it "returns stories when 'items' header is provided without 'since_id'" do
       StoryRepository.should_receive(:unread).twice.and_return([story_one, story_two])
-      make_request({ items: nil })
-      answer.merge!({ items: [story_one.as_fever_json, story_two.as_fever_json], total_items: 2 })
+      make_request(items: nil)
+      answer.merge!(items: [story_one.as_fever_json, story_two.as_fever_json], total_items: 2)
       last_response.should be_ok
       last_response.body.should == answer.to_json
     end
 
     it "returns stories ids when 'items' header is provided along with 'with_ids'" do
       StoryRepository.should_receive(:fetch_by_ids).twice.with(['5']).and_return([story_one])
-      make_request({ items: nil, with_ids: 5 })
-      answer.merge!({ items: [story_one.as_fever_json], total_items: 1 })
+      make_request(items: nil, with_ids: 5)
+      answer.merge!(items: [story_one.as_fever_json], total_items: 1)
       last_response.should be_ok
       last_response.body.should == answer.to_json
     end
 
     it "returns links as empty array when 'links' header is provided" do
-      make_request({ links: nil })
-      answer.merge!({ links: [] })
+      make_request(links: nil)
+      answer.merge!(links: [])
       last_response.should be_ok
       last_response.body.should == answer.to_json
     end
 
     it "returns unread items ids when 'unread_item_ids' header is provided" do
       StoryRepository.should_receive(:unread).and_return([story_one, story_two])
-      make_request({ unread_item_ids: nil })
-      answer.merge!({ unread_item_ids: [story_one.id,story_two.id].join(',') })
+      make_request(unread_item_ids: nil)
+      answer.merge!(unread_item_ids: [story_one.id,story_two.id].join(','))
       last_response.should be_ok
       last_response.body.should == answer.to_json
     end
 
     it "returns starred items when 'saved_item_ids' header is provided" do
       Story.should_receive(:where).with({ is_starred: true }).and_return([story_one, story_two])
-      make_request({ saved_item_ids: nil })
-      answer.merge!({ saved_item_ids: [story_one.id,story_two.id].join(',') })
+      make_request(saved_item_ids: nil)
+      answer.merge!(saved_item_ids: [story_one.id,story_two.id].join(','))
       last_response.should be_ok
       last_response.body.should == answer.to_json
     end
@@ -157,7 +159,14 @@ describe FeverAPI do
 
     it "commands to mark group as read" do
       MarkGroupAsRead.should_receive(:new).with('10', '1375080946').and_return(double(mark_group_as_read: true))
-      make_request({ mark: 'group', as: 'read', id: 10, before: 1375080946 })
+      make_request(mark: 'group', as: 'read', id: 10, before: 1375080946)
+      last_response.should be_ok
+      last_response.body.should == answer.to_json
+    end
+
+    it "commands to mark entire feed as read" do
+      MarkFeedAsRead.should_receive(:new).with('20', '1375080945').and_return(double(mark_feed_as_read: true))
+      make_request(mark: 'feed', as: 'read', id: 20, before: 1375080945)
       last_response.should be_ok
       last_response.body.should == answer.to_json
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ Coveralls.wear!
 require "factories/feed_factory"
 require "factories/story_factory"
 require "factories/user_factory"
+require "factories/group_factory"
 
 require "./app"
 

--- a/spec/support/files/subscriptions.xml
+++ b/spec/support/files/subscriptions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+    <head>
+        <title>subscriptions title</title>
+    </head>
+    <body>
+        <outline text="Autoblog" title="Autoblog" type="rss"
+            xmlUrl="http://feeds.autoblog.com/weblogsinc/autoblog/" htmlUrl="http://www.autoblog.com"/>
+        <outline text="City Guide News" title="City Guide News"
+            type="rss"
+            xmlUrl="http://www.probki.net/news/RSS_news_feed.asp" htmlUrl="http://www.probki.net"/>
+        <outline title="Football News" text="Football News">
+            <outline text="TMW Football Transfer News"
+                title="TMW Football Transfer News" type="rss"
+                xmlUrl="http://www.transfermarketweb.com/rss" htmlUrl="http://www.transfermarketweb.com"/>
+        </outline>
+        <outline title="RoR" text="RoR">
+            <outline
+                text="GIANT ROBOTS SMASHING INTO OTHER GIANT ROBOTS - Home"
+                title="GIANT ROBOTS SMASHING INTO OTHER GIANT ROBOTS - Home"
+                type="rss"
+                xmlUrl="http://feeds.feedburner.com/GiantRobotsSmashingIntoOtherGiantRobots" htmlUrl="http://robots.thoughtbot.com/"/>
+            <outline text="igvita.com" title="igvita.com" type="rss"
+                xmlUrl="http://www.igvita.com/feed/" htmlUrl="http://www.igvita.com"/>
+        </outline>
+    </body>
+</opml>

--- a/spec/utils/opml_parser_spec.rb
+++ b/spec/utils/opml_parser_spec.rb
@@ -22,12 +22,14 @@ describe OpmlParser do
         </opml>
       eos
 
-      result.count.should eq 2
-      result.first[:name].should eq "a sample feed"
-      result.first[:url].should eq "http://feeds.feedburner.com/foobar"
-    
-      result.last[:name].should eq "Matt's Blog"
-      result.last[:url].should eq "http://mdswanson.com/atom.xml"
+      resulted_values = result.values.flatten
+      resulted_values.size.should eq 2
+      resulted_values.first[:name].should eq "a sample feed"
+      resulted_values.first[:url].should eq "http://feeds.feedburner.com/foobar"
+
+      resulted_values.last[:name].should eq "Matt's Blog"
+      resulted_values.last[:url].should eq "http://mdswanson.com/atom.xml"
+      result.keys.first.should eq "Ungrouped"
     end
 
     it "handles nested groups of feeds" do
@@ -45,10 +47,12 @@ describe OpmlParser do
         </body>
         </opml>
       eos
+      resulted_values = result.values.flatten
 
-      result.count.should eq 1
-      result.first[:name].should eq "a sample feed"
-      result.first[:url].should eq "http://feeds.feedburner.com/foobar"
+      resulted_values.count.should eq 1
+      resulted_values.first[:name].should eq "a sample feed"
+      resulted_values.first[:url].should eq "http://feeds.feedburner.com/foobar"
+      result.keys.first.should eq "Technology News"
     end
 
     it "doesn't explode when there are no feeds" do
@@ -79,9 +83,10 @@ describe OpmlParser do
         </body>
         </opml>
       eos
+      resulted_values = result.values.flatten
 
-      result.count.should eq 1
-      result.first[:name].should eq "a sample feed"
+      resulted_values.count.should eq 1
+      resulted_values.first[:name].should eq "a sample feed"
     end
   end
 end


### PR DESCRIPTION
There are some feature requests about adding groups for feeds. Currently I'm trying to implement such feature, but I find this a bit complicated due to design, usability and other front-end issues. However, adding groups to fever API is simple and straightforward, so I thought that having groups at least in the clients would be great.

These changes do not affect UI at any way. Also I modified `opml_parser.rb` and `import_from_opml.rb` to consider groups so you can re-import the same `subscriptions.xml` just to attach existing feeds to groups.

Tested on Reeder for iPhone.
