### PR TITLE
Mark all items read when the fever group_id is 0

### DIFF
--- a/app/commands/stories/mark_group_as_read.rb
+++ b/app/commands/stories/mark_group_as_read.rb
@@ -1,6 +1,9 @@
 require_relative "../../repositories/story_repository"
 
 class MarkGroupAsRead
+  KINDLING_GROUP_ID            = 1
+  SPARKS_AND_KINDLING_GROUP_ID = 0
+
   def initialize(group_id, timestamp, repository = StoryRepository)
     @group_id  = group_id.to_i
     @repo      = repository
@@ -8,7 +11,9 @@ class MarkGroupAsRead
   end
 
   def mark_group_as_read
-    @repo.fetch_unread_by_timestamp(@timestamp).update_all(is_read: true) if @group_id == 1
+    if [SPARKS_AND_KINDLING_GROUP_ID, KINDLING_GROUP_ID].include? @group_id
+      @repo.fetch_unread_by_timestamp(@timestamp).update_all(is_read: true)
+    end
   end
 end
 

--- a/spec/commands/stories/mark_group_as_read_spec.rb
+++ b/spec/commands/stories/mark_group_as_read_spec.rb
@@ -7,6 +7,12 @@ describe MarkGroupAsRead do
     let(:stories) { stub }
     let(:repo){ stub(fetch_unread_by_timestamp: stories) }
 
+    it "marks group 0 as read" do
+      command = MarkGroupAsRead.new(0, Time.now.to_i, repo)
+      stories.should_receive(:update_all).with(is_read: true)
+      command.mark_group_as_read
+    end
+
     it "marks group 1 as read" do
       command = MarkGroupAsRead.new(1, Time.now.to_i, repo)
       stories.should_receive(:update_all).with(is_read: true)


### PR DESCRIPTION
Stringer is not currently marking all items as read when the `group_id` is 0. The Fever API docs state:

> You can mark the “Kindling” super group (and the “Sparks” super group) as read by adding the following four arguments to your POST data:
> 
> mark=group
> as=read
> id=0
> before=? where ? is replaced with the Unix timestamp of the the local client’s last items API request

Stringer has no notion of kindling, in this case it's safe to mark all items read.
