### PR TITLE
Add ImportFromText

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,12 @@ require "./app"
 require_relative "./app/tasks/fetch_feeds"
 require_relative "./app/tasks/change_password"
 require_relative "./app/tasks/remove_old_stories.rb"
+require_relative "./app/commands/feeds/import_from_text"
+
+desc "Import list of feeds."
+task :import_feeds_list do
+  ImportFromText.import("import_list.txt")
+end
 
 desc "Fetch all feeds."
 task :fetch_feeds do

--- a/app/commands/feeds/import_from_text.rb
+++ b/app/commands/feeds/import_from_text.rb
@@ -1,0 +1,12 @@
+require_relative "./add_new_feed"
+
+class ImportFromText
+  def self.import(file_name)
+    text = File.open(file_name).read
+    text.gsub!(/\r\n?/, "\n")
+
+    text.each_line do |line|
+      AddNewFeed.add(line)
+    end
+  end
+end


### PR DESCRIPTION
I have been keeping a list of websites I would like to subscribe to when I do find an RSS feed reader, in a plain text file. I noticed there was the ability to import from OPML but that didn't suit my needs, so I added the ability to import from a plain text file.

Users can create an `import_list.txt` file in the root of the project, and after commiting + deploying that file, they may run `heroku run rake import_feeds_list`.

Potentially a web interface could be created for this, like we have for OPML imports. A Rake task suited me.
