### PR TITLE
Sets 30sec connection timeout for feed parsing

### DIFF
--- a/app/tasks/fetch_feed.rb
+++ b/app/tasks/fetch_feed.rb
@@ -13,7 +13,7 @@ class FetchFeed
 
   def fetch
     begin
-      raw_feed = @parser.fetch_and_parse(@feed.url, user_agent: "Stringer", if_modified_since: @feed.last_fetched)
+      raw_feed = @parser.fetch_and_parse(@feed.url, user_agent: "Stringer", if_modified_since: @feed.last_fetched, timeout: 30)
 
       if raw_feed == 304
         @logger.info "#{@feed.url} has not been modified since last fetch" if @logger


### PR DESCRIPTION
I have a feed which is unavailable right now. By default curl (and curb) do not set a timeout, so it kept there trying to connect to the server. As a result I had a bunch of ruby processes that were stuck trying to connect to that feed which caused my server to go out of memory.

I think 30 seconds is an okay default. What do you think?
