### PR TITLE
Add tasks that enqueue fetching of feeds

### DIFF
--- a/app/jobs/fetch_feed_job.rb
+++ b/app/jobs/fetch_feed_job.rb
@@ -1,0 +1,6 @@
+class FetchFeedJob < Struct.new(:feed_id)
+  def perform
+    feed = FeedRepository.fetch(feed_id)
+    FetchFeed.new(feed).fetch
+  end
+end

--- a/app/repositories/feed_repository.rb
+++ b/app/repositories/feed_repository.rb
@@ -3,6 +3,10 @@ require_relative "../models/feed"
 class FeedRepository
   MIN_YEAR = 1970
 
+  def self.fetch(id)
+    Feed.find(id)
+  end
+
   def self.update_last_fetched(feed, timestamp)
     is_invalid_timestamp = timestamp.nil? || timestamp.year < MIN_YEAR
 


### PR DESCRIPTION
Adds two new Rake tasks `enqueue_fetch_feeds` and `enqueue_fetch_feed` that mimic the current tasks `fetch_feeds` and `fetch_feed`, except that they add jobs to the Delayed::Job queue instead of fetching the feeds directly. References #259.
