### PR TITLE
Experiment with workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ cd stringer
 heroku create
 git push heroku master
 
+heroku config:set APP_URL=`heroku apps:info | grep -o 'http[^"]*'`
 heroku config:set SECRET_TOKEN=`openssl rand -hex 20`
 
 heroku run rake db:migrate

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,11 @@
 require "sinatra/activerecord/rake"
 require "rubygems"
 require "bundler"
+require "net/http"
 Bundler.require
 
 require "./app"
+require_relative "./app/jobs/fetch_feed_job"
 require_relative "./app/tasks/fetch_feeds"
 require_relative "./app/tasks/change_password"
 require_relative "./app/tasks/remove_old_stories.rb"
@@ -11,6 +13,18 @@ require_relative "./app/tasks/remove_old_stories.rb"
 desc "Fetch all feeds."
 task :fetch_feeds do
   FetchFeeds.new(Feed.all).fetch_all
+end
+
+desc "Lazily fetch all feeds."
+task :lazy_fetch do
+  if ENV['APP_URL']
+    uri = URI(ENV['APP_URL'])
+    Net::HTTP.get_response(uri)
+  end
+
+  FeedRepository.list.each do |feed|
+    Delayed::Job.enqueue FetchFeedJob.new(feed.id)
+  end
 end
 
 desc "Fetch single feed"
@@ -25,7 +39,12 @@ end
 
 desc "Work the delayed_job queue."
 task :work_jobs do
-  Delayed::Worker.new(:min_priority => ENV['MIN_PRIORITY'], :max_priority => ENV['MAX_PRIORITY']).start
+  Delayed::Job.delete_all
+
+  3.times do
+    Delayed::Worker.new(:min_priority => ENV['MIN_PRIORITY'], 
+      :max_priority => ENV['MAX_PRIORITY']).start
+  end
 end
 
 desc "Change your password"

--- a/app/jobs/fetch_feed_job.rb
+++ b/app/jobs/fetch_feed_job.rb
@@ -1,0 +1,6 @@
+class FetchFeedJob < Struct.new(:feed_id)
+  def perform
+    feed = FeedRepository.fetch(feed_id)
+    FetchFeed.new(feed).fetch
+  end
+end

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,4 +1,4 @@
-worker_processes 3
+worker_processes 1
 timeout 30
 preload_app true
 


### PR DESCRIPTION
I've been playing around with doing the feed fetching/parsing in the delayed job queue instead of the scheduler (to address costs mentioned in #259). The `3.times` spawning workers stuff seems Bad, but it has been running okay for me. The whole running DJ in a unicorn worker is definitely not the preferred method.

There is some legwork of setting your app url and forcing the dyno to wake up before we queue (otherwise the dyno would be idle and not process...I think, didn't really play with it too much).

Here is my dyno usage for the scheduler process after deploying this branch on Sept 17
![image](https://f.cloud.github.com/assets/56947/1241246/634a1d1c-2a19-11e3-8170-6e41fc197ccc.png)

Long and the short of it: this has been working for me, but could use a bit of cleaning up still.
