### PR TITLE
Better error handling of 'fetch_feeds'

### DIFF
--- a/app/tasks/fetch_feed.rb
+++ b/app/tasks/fetch_feed.rb
@@ -16,7 +16,7 @@ class FetchFeed
 
   def fetch
     begin
-      raw_feed = @parser.fetch_and_parse(@feed.url, user_agent: USER_AGENT, if_modified_since: @feed.last_fetched, timeout: 30)
+      raw_feed = @parser.fetch_and_parse(@feed.url, user_agent: USER_AGENT, if_modified_since: @feed.last_fetched, timeout: 30, max_redirects: 2)
 
       if raw_feed == 304
         @logger.info "#{@feed.url} has not been modified since last fetch" if @logger


### PR DESCRIPTION
Today I ran into the issue that, a feed url has a problem which '/feed/' redirects to '/feed', and then '/feed' redirects to '/feed/'. That caused 'fetch_feeds' cron never ends, and when I checked that, plenty of them were running.

I think we also need consider what we do for redirects. As far as I can tell, some scrapers don't handle redirects, JFYI.
