### PR TITLE
Modified Ruby Version in Step 9, and added Step 10 to remove 'pry-byebug' gem which depends on Ruby 2.0

### DIFF
--- a/docs/OpenShift.md
+++ b/docs/OpenShift.md
@@ -56,7 +56,7 @@ Deploying into OpenShift
 		password: <%= ENV["OPENSHIFT_POSTGRESQL_DB_PASSWORD"] %> 
  ```
 
-8. Due to an older version of bundler being used in OpenShift (1.1.4), it does not support indicating the ruby version in the Gemfile. Remove the line from the Gemfile below. (Referencing issue #266)
+8. Due to an older version of bundler being used in OpenShift (1.1.4), it does not support indicating the ruby version in the Gemfile. Remove the line from the Gemfile below. (Referencing issue [#266](https://github.com/swanson/stringer/issues/266))
 
  ```
     ruby '2.0.0'


### PR DESCRIPTION
Referencing #294.

Updated the Ruby version in Step 9.

Added Step 10 to remove the 'pry-byebug' gem which depends on Ruby 2.0. Opted for this as it seems the most straight-forward and easiest change. Maybe I should add a note indicating that this is only for OpenShift production deployment, or is this fine?
