### PR TITLE
Add a unique secret token to install instructions

### DIFF
--- a/docs/VPS.md
+++ b/docs/VPS.md
@@ -89,7 +89,7 @@ Stringer uses environment variables to determine information about your database
     echo 'export STRINGER_DATABASE_USERNAME="stringer"' >> $HOME/.bash_profile
     echo 'export STRINGER_DATABASE_PASSWORD="EDIT_ME"' >> $HOME/.bash_profile
     echo 'export RACK_ENV="production"' >> $HOME/.bash_profile
-    echo 'export SECRET_TOKEN="$$$RANDOM"` >> $HOME/.bash_profile
+    echo "export SECRET_TOKEN=`openssl rand -hex 20`" >> $HOME/.bash_profile
     source ~/.bash_profile
     
 Tell stringer to run the database in production mode, using the postgres database you created earlier.


### PR DESCRIPTION
Failing to do so means that if you have multiple stringer installs on the same host, one password will grant you access to all of them.
