### PR TITLE
Loosen unprintable character sanitization to not remove valid line-endings

### DIFF
--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -86,7 +86,8 @@ class StoryRepository
     Loofah.fragment(content.gsub(/<wbr\s*>/i, ""))
           .scrub!(:prune)
           .to_s
-          .gsub(/[^[:print:]]/, '')
+          .gsub("\u2028", '')
+          .gsub("\u2029", '')
   end
 
   def self.expand_absolute_urls(content, base_url)

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -88,8 +88,13 @@ describe StoryRepository do
       end
 
       it "handles unprintable characters" do
-        result = StoryRepository.sanitize("n ")
+        result = StoryRepository.sanitize("n\u2028\u2029")
         result.should eq "n"
+      end
+
+      it "preserves line endings" do
+        result = StoryRepository.sanitize("test\r\ncase")
+        result.should eq "test\r\ncase"
       end
     end
   end


### PR DESCRIPTION
So @inpermutation and I noticed that some feeds with `\r` or `\n` had words running together.

Example:

`This is a test\r\ncase`

Was displayed as 

`This is a testcase`

We were too aggressive with our fixing of #295 - `[:print:]` is catching `\r\n` so let's explicitly fix the weird JSON unicode chars (this aligns with the rack fix as well: https://github.com/rack/rack-contrib/pull/37/files).
