### PR TITLE
add clockwork fetch_feeds_worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "activerecord", "~> 4.0"
 # need to work around bug in 4.0.1 https://github.com/rails/arel/pull/216
 gem 'arel', git: 'git://github.com/rails/arel.git', branch: '4-0-stable'
 gem "bcrypt-ruby", "~> 3.1.2"
+gem "clockwork", "0.7.5"
 gem "delayed_job", "~> 4.0"
 gem "delayed_job_active_record", "~> 4.0"
 gem "feedbag", "~> 0.9.2"

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ Bundler.setup
 require "rubygems"
 require "net/http"
 require 'active_record'
+require 'clockwork'
 require 'delayed_job'
 require 'delayed_job_active_record'
 
@@ -18,6 +19,14 @@ require_relative "./app/tasks/remove_old_stories.rb"
 desc "Fetch all feeds."
 task :fetch_feeds do
   FetchFeeds.new(Feed.all).fetch_all
+end
+
+desc "Fetch all feeds every 30m."
+task :fetch_feeds_worker do
+  Clockwork.every(30.minutes, 'Queueing fetch all feeds.') do
+    FetchFeeds.new(Feed.all).fetch_all
+  end
+  Clockwork.run
 end
 
 desc "Lazily fetch all feeds."


### PR DESCRIPTION
This commit adds a new rake task that fetches all feeds every 30 minutes in a
Clockwork process.

To use Stringer in something like Docker, it's possible to add the task in the
Procfile and just run foreman start.

Example:

```
echo "worker: rake fetch_feeds_worker" >> Procfile
```

Thanks!
