### PR TITLE
Style stories marked as "keep unread"

### DIFF
--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -136,6 +136,10 @@ li.story.read {
   opacity: 0.5;
 }
 
+li.story.keepUnread .story-preview {
+  font-weight: bold;
+}
+
 li.story.open {
   opacity: 1.0;
 }

--- a/app/public/js/app.js
+++ b/app/public/js/app.js
@@ -105,6 +105,9 @@ var StoryView = Backbone.View.extend({
     if (jsonModel.is_read) {
       this.$el.addClass('read');
     }
+    if (jsonModel.keep_unread) {
+      this.$el.addClass('keepUnread');
+    }
     return this;
   },
 
@@ -131,6 +134,7 @@ var StoryView = Backbone.View.extend({
   itemKeepUnread: function() {
     var icon = this.model.get("keep_unread") ? "icon-check" : "icon-check-empty";
     this.$(".story-keep-unread > i").attr("class", icon);
+    this.$el.toggleClass("keepUnread", this.model.get("keep_unread"));
   },
 
   itemStarred: function() {


### PR DESCRIPTION
Adds styling to stories marked as "keep unread", so they can be distinguished from never-read stories. It currently just makes the title bold, but this can easily be changed.

Fixes #210.
