### PR TITLE
Clean up Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development do
 end
 
 group :development, :test do
+  gem "capybara", "~> 2.4.1"
   gem "coveralls", "~> 0.7", require: false
   gem "faker", "~> 1.2"
   gem "pry-byebug", "~> 1.2"
@@ -18,13 +19,11 @@ group :development, :test do
   gem "rspec", "~> 2.14", ">= 2.14.1"
   gem "rspec-html-matchers", "~> 0.4.3"
   gem "shotgun", "~> 0.9.0"
-  gem "capybara", "~> 2.4.1"
   gem "timecop", "~> 0.7.1"
 end
 
 gem "activerecord", "~> 4.0"
-# need to work around bug in 4.0.1 https://github.com/rails/arel/pull/216
-gem 'arel', git: 'git://github.com/rails/arel.git', branch: '4-0-stable'
+gem "arel", "~> 4.0.2"
 gem "bcrypt-ruby", "~> 3.1.2"
 gem "delayed_job", "~> 4.0"
 gem "delayed_job_active_record", "~> 4.0"
@@ -34,13 +33,13 @@ gem "highline", "~> 1.6", ">= 1.6.20", require: false
 gem "i18n", "~> 0.6.9"
 gem "loofah", "~> 2.0.0"
 gem "nokogiri", "~> 1.6"
+gem "rack-ssl", "~> 1.4.1"
 gem "racksh", "~> 1.0"
 gem "rake", "~> 10.1", ">= 10.1.1"
 gem "sinatra", "~> 1.4", ">= 1.4.4"
-gem "sinatra-assetpack", "~> 0.3.1", require: "sinatra/assetpack"
 gem "sinatra-activerecord", "~> 1.2", ">= 1.2.3"
+gem "sinatra-assetpack", "~> 0.3.1", require: "sinatra/assetpack"
 gem "sinatra-contrib", ">= 1.4.2"
 gem "sinatra-flash", "~> 0.3.0"
 gem "thread", "~> 0.1.3"
 gem "will_paginate", "~> 3.0", ">= 3.0.5"
-gem "rack-ssl"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: git://github.com/rails/arel.git
-  revision: 454a25f18c95cdfba5520a6fc5bdb6d476e20a85
-  branch: 4-0-stable
-  specs:
-    arel (4.0.1.20131022201058)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -23,6 +16,7 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
+    arel (4.0.2)
     atomic (1.1.14)
     backports (3.3.5)
     bcrypt-ruby (3.1.2)
@@ -163,7 +157,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 4.0)
-  arel!
+  arel (~> 4.0.2)
   bcrypt-ruby (~> 3.1.2)
   capybara (~> 2.4.1)
   coveralls (~> 0.7)
@@ -178,7 +172,7 @@ DEPENDENCIES
   nokogiri (~> 1.6)
   pg (~> 0.17.1)
   pry-byebug (~> 1.2)
-  rack-ssl
+  rack-ssl (~> 1.4.1)
   rack-test (~> 0.6.2)
   racksh (~> 1.0)
   rake (~> 10.1, >= 10.1.1)


### PR DESCRIPTION
- Sort gem declarations lexicographically.
- Use `arel` from RubyGems.org.
- Add pessimistic version lock on `rack-ssl`.

Fixes #334.
