### PR TITLE
Update OpenShift Docs for Ruby 2.0 Cartridge 

### DIFF
--- a/docs/OpenShift.md
+++ b/docs/OpenShift.md
@@ -26,25 +26,19 @@ Deploying into OpenShift
 	popd > /dev/null
  ```
 
-4. Next, a secret is needed for the application. Generate the secret by running:
+4. Make sure that the file created above is executable on Unix-like systems.
 
  ```sh
-    openssl rand -hex 20
+    chmod +x .openshift/action_hooks/deploy
  ```
 
-5. Add the generated secret into a new file, .openshift/action_hooks/pre_start_ruby-2.0, in the format below.
-
- ```
-    export SECRET_TOKEN="generated_secret"
- ```
-
-6. Make sure that the 2 files created above are executable on Unix-like systems.
+5. Set the SECRET_TOKEN as a rhc environment variable by generating it with the command below.
 
  ```sh
-    chmod +x .openshift/action_hooks/deploy .openshift/action_hooks/pre_start_ruby-2.0
+    rhc env set SECRET_TOKEN="`openssl rand -hex 20`"
  ```
 
-7. Configuration of the database server is next. Open the file config/database.yml and add in the configuration for Production as shown below. OpenShift is able to use environment variables to push the information into the application.
+6. Configuration of the database server is next. Open the file config/database.yml and add in the configuration for Production as shown below. OpenShift is able to use environment variables to push the information into the application.
 
  ```
 	production:
@@ -56,7 +50,7 @@ Deploying into OpenShift
 		password: <%= ENV["OPENSHIFT_POSTGRESQL_DB_PASSWORD"] %> 
  ```
 
-8. Due to an older version of bundler being used in OpenShift (1.3.5), some changes need to be made in the Gemfile. 
+7. Due to an older version of bundler being used in OpenShift (1.3.5), some changes need to be made in the Gemfile. 
 
 	Remove the Ruby version specification from the Gemfile below (error reporting wrong Ruby version when deploying to OpenShift). 
 
@@ -76,7 +70,7 @@ Deploying into OpenShift
 	gem "sinatra-assetpack", "~> 0.3.1", :require => "sinatra/assetpack"
  ```
 
-9. Finally, once completed, all changes should be committed and pushed to OpenShift. Note that it might take a while when pushing to OpenShift.
+8. Finally, once completed, all changes should be committed and pushed to OpenShift. Note that it might take a while when pushing to OpenShift.
 
  ```sh
 	git add .
@@ -84,7 +78,7 @@ Deploying into OpenShift
 	git push origin
  ```
 
-10. Check that you are able to access the website at the URL given, i.e. feeds-username.rhcloud.com. Then set your password, import your feeds and all good to go!
+9. Check that you are able to access the website at the URL given, i.e. feeds-username.rhcloud.com. Then set your password, import your feeds and all good to go!
 
 
 Adding Cronjob to Fetch Feeds


### PR DESCRIPTION
Small update to the OpenShift docs to use OpenShift's latest Ruby 2.0 Cartridge. But OpenShift's Bundler still seems a little old, resulting in some workarounds.
