### PR TITLE
Add instructions to install foreman

### DIFF
--- a/docs/VPS.md
+++ b/docs/VPS.md
@@ -69,6 +69,10 @@ We also need to install bundler which will handle Stringer's dependencies
 
     gem install bundler
     rbenv rehash
+    
+We will also need foreman to run our app
+
+    gem install foreman
 
 Install Stringer and set it up
 ==============================
@@ -99,7 +103,7 @@ Tell stringer to run the database in production mode, using the postgres databas
 
 Run the application:
 
-    bundle exec foreman start
+    foreman start
 
 Set up a cron job to parse the rss feeds. 
 


### PR DESCRIPTION
Since pull request https://github.com/swanson/stringer/pull/336 foreman is no longer part of the Gemfile. This needs installing separately as it's not covered by the bundle install (which uses the Gemfile). Finally bundle exec will no longer work on foreman as it's no longer part of the Gemfile so removed the "bundle exec" prefix for starting the application.
