### PR TITLE
Deps: switch from Unicorn to Puma

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,9 @@ Style/Documentation:
 Style/DoubleNegation:
   Enabled: false
 
+Style/MissingElse:
+  Enabled: false
+
 Style/NumericLiterals:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -551,7 +551,6 @@ Style/MissingElse:
     - 'app/fever_api/write_mark_item.rb'
     - 'app/helpers/url_helpers.rb'
     - 'app/repositories/story_repository.rb'
-    - 'config/unicorn.rb'
     - 'spec/support/coverage.rb'
 
 # Offense count: 1

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,6 @@ ruby_version_file = File.expand_path(".ruby-version", __dir__)
 ruby File.read(ruby_version_file).chomp if File.readable?(ruby_version_file)
 source "https://rubygems.org"
 
-group :production do
-  gem "pg"
-  gem "unicorn"
-end
-
 group :development do
   gem "rubocop", require: false
   gem "rubocop-rails", require: false
@@ -37,6 +32,8 @@ gem "httparty"
 gem "i18n"
 gem "loofah"
 gem "nokogiri"
+gem "pg"
+gem "puma"
 gem "rack-protection"
 gem "racksh"
 gem "rack-ssl"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,6 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    kgio (2.11.4)
     loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -72,6 +71,7 @@ GEM
     multi_xml (0.6.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
@@ -87,6 +87,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
+    puma (5.5.2)
+      nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-protection (2.1.0)
@@ -99,7 +101,6 @@ GEM
       rack (>= 1.0)
       rack-test (>= 0.5)
     rainbow (3.0.0)
-    raindrops (0.20.0)
     rake (13.0.6)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
@@ -192,9 +193,6 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.1.0)
-    unicorn (6.0.0)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
     will_paginate (3.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -219,6 +217,7 @@ DEPENDENCIES
   nokogiri
   pg
   pry-byebug
+  puma
   rack-protection
   rack-ssl
   rack-test
@@ -242,11 +241,10 @@ DEPENDENCIES
   thread
   timecop
   uglifier
-  unicorn
   will_paginate
 
 RUBY VERSION
    ruby 2.7.5
 
 BUNDLED WITH
-   2.2.12
+   2.2.33

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
+web: bundle exec puma -p $PORT -C ./config/puma.rb
 console: bundle exec racksh

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -2,8 +2,8 @@
 nodaemon=true
 loglevel=debug
 
-[program:unicorn]
-command=bash -c 'bundle exec rake db:migrate && bundle exec unicorn -p $PORT -c ./config/unicorn.rb'
+[program:puma]
+command=bash -c 'bundle exec rake db:migrate && bundle exec puma -p $PORT -C ./config/puma.rb'
 directory=/app
 autostart=true
 autorestart=true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ require_relative "factories"
 
 require "./app"
 
-Capybara.server = :webrick
+Capybara.server = :puma, { Silent: true }
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods


### PR DESCRIPTION
**What**

This switches the server we use from Unicorn to Puma

**Why**

* Puma is the blessed option [on Heroku][heroku].
* It [works with Capybara][capybara] out of the box.
* Ruby 3 [removes `webrick`][ruby3] from the core libraries, so we would
  need to add it as a dependency for Capybara when upgrading. Might as
  well consolidate on a single server.

**Notes**

I also moved `pg` out of the `production` group.

[heroku]: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#recommended-default-puma-process-and-thread-configuration
[capybara]: https://github.com/teamcapybara/capybara#drivers
[ruby3]: https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/
