### PR TITLE
Docker: upgrade Ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.3
+FROM ruby:2.7.5
 
 ENV RACK_ENV=production
 ENV PORT=8080
@@ -7,7 +7,7 @@ EXPOSE 8080
 
 WORKDIR /app
 ADD Gemfile Gemfile.lock /app/
-RUN bundle install --deployment
+RUN bundle install
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ But it does have keyboard shortcuts and was made with love!
 
 ## Installation
 
-Stringer is a Ruby (2.3.0+) app based on Sinatra, ActiveRecord, PostgreSQL, Backbone.js and DelayedJob.
+Stringer is a Ruby app based on Sinatra, ActiveRecord, PostgreSQL, Backbone.js and DelayedJob.
 
 [![Deploy to Heroku](https://cdn.herokuapp.com/deploy/button.svg)](https://heroku.com/deploy)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - POSTGRES_DB=stringer
 
   web:
-    image: mdswanson/stringer
+    image: mockdeep/stringer
     depends_on:
       - postgres
     restart: always


### PR DESCRIPTION
Not sure, but I believe this will fix issues with HTTPS.

I also removed the deprecated `--deployment` flag when running `bundle
install`.
