### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
 
   web:
     image: mockdeep/stringer
+    build: .
     depends_on:
       - postgres
     restart: always


### PR DESCRIPTION
Add build directive so running `docker-compose up` will work on first run.

Just a couple other notes:
- `mockdeep/stringer` doesn't contain a 'latest' tag so if you try to use the docker-compose.yml outside the repo you will get a manifest error.
- If you add the `0.1` tag to get the proper version, it continually fails with the following:
```
/app/start.sh: 13: cannot create /app/crontab: Permission denied
Traceback (most recent call last):
  File "/usr/bin/supervisord", line 33, in <module>
    sys.exit(load_entry_point('supervisor==4.2.2', 'console_scripts', 'supervisord')())
  File "/usr/lib/python3/dist-packages/supervisor/supervisord.py", line 359, in main
    go(options)
  File "/usr/lib/python3/dist-packages/supervisor/supervisord.py", line 369, in go
    d.main()
  File "/usr/lib/python3/dist-packages/supervisor/supervisord.py", line 72, in main
    self.options.make_logger()
  File "/usr/lib/python3/dist-packages/supervisor/options.py", line 1494, in make_logger
    loggers.handle_file(
  File "/usr/lib/python3/dist-packages/supervisor/loggers.py", line 419, in handle_file
    handler = RotatingFileHandler(filename, 'a', maxbytes, backups)
  File "/usr/lib/python3/dist-packages/supervisor/loggers.py", line 213, in __init__
    FileHandler.__init__(self, filename, mode)
  File "/usr/lib/python3/dist-packages/supervisor/loggers.py", line 160, in __init__
    self.stream = open(filename, mode)
PermissionError: [Errno 13] Permission denied: '/app/supervisord.log'
```