### PR TITLE
Replacing removed update_attributes method

### DIFF
--- a/app/commands/stories/mark_as_read.rb
+++ b/app/commands/stories/mark_as_read.rb
@@ -7,6 +7,6 @@ class MarkAsRead
   end
 
   def mark_as_read
-    @repo.fetch(@story_id).update_attributes(is_read: true)
+    @repo.fetch(@story_id).update(is_read: true)
   end
 end

--- a/app/commands/stories/mark_as_read.rb
+++ b/app/commands/stories/mark_as_read.rb
@@ -1,12 +1,11 @@
 require_relative "../../repositories/story_repository"
 
 class MarkAsRead
-  def initialize(story_id, repository = StoryRepository)
+  def initialize(story_id)
     @story_id = story_id
-    @repo = repository
   end
 
   def mark_as_read
-    @repo.fetch(@story_id).update(is_read: true)
+    StoryRepository.fetch(@story_id).update!(is_read: true)
   end
 end

--- a/app/commands/stories/mark_as_starred.rb
+++ b/app/commands/stories/mark_as_starred.rb
@@ -7,6 +7,6 @@ class MarkAsStarred
   end
 
   def mark_as_starred
-    @repo.fetch(@story_id).update_attributes(is_starred: true)
+    @repo.fetch(@story_id).update(is_starred: true)
   end
 end

--- a/app/commands/stories/mark_as_starred.rb
+++ b/app/commands/stories/mark_as_starred.rb
@@ -1,12 +1,11 @@
 require_relative "../../repositories/story_repository"
 
 class MarkAsStarred
-  def initialize(story_id, repository = StoryRepository)
+  def initialize(story_id)
     @story_id = story_id
-    @repo = repository
   end
 
   def mark_as_starred
-    @repo.fetch(@story_id).update(is_starred: true)
+    StoryRepository.fetch(@story_id).update!(is_starred: true)
   end
 end

--- a/app/commands/stories/mark_as_unread.rb
+++ b/app/commands/stories/mark_as_unread.rb
@@ -7,6 +7,6 @@ class MarkAsUnread
   end
 
   def mark_as_unread
-    @repo.fetch(@story_id).update_attributes(is_read: false)
+    @repo.fetch(@story_id).update(is_read: false)
   end
 end

--- a/app/commands/stories/mark_as_unread.rb
+++ b/app/commands/stories/mark_as_unread.rb
@@ -1,12 +1,11 @@
 require_relative "../../repositories/story_repository"
 
 class MarkAsUnread
-  def initialize(story_id, repository = StoryRepository)
+  def initialize(story_id)
     @story_id = story_id
-    @repo = repository
   end
 
   def mark_as_unread
-    @repo.fetch(@story_id).update(is_read: false)
+    StoryRepository.fetch(@story_id).update!(is_read: false)
   end
 end

--- a/app/commands/stories/mark_as_unstarred.rb
+++ b/app/commands/stories/mark_as_unstarred.rb
@@ -7,6 +7,6 @@ class MarkAsUnstarred
   end
 
   def mark_as_unstarred
-    @repo.fetch(@story_id).update_attributes(is_starred: false)
+    @repo.fetch(@story_id).update(is_starred: false)
   end
 end

--- a/app/commands/stories/mark_as_unstarred.rb
+++ b/app/commands/stories/mark_as_unstarred.rb
@@ -1,12 +1,11 @@
 require_relative "../../repositories/story_repository"
 
 class MarkAsUnstarred
-  def initialize(story_id, repository = StoryRepository)
+  def initialize(story_id)
     @story_id = story_id
-    @repo = repository
   end
 
   def mark_as_unstarred
-    @repo.fetch(@story_id).update(is_starred: false)
+    StoryRepository.fetch(@story_id).update!(is_starred: false)
   end
 end

--- a/spec/commands/stories/mark_as_read_spec.rb
+++ b/spec/commands/stories/mark_as_read_spec.rb
@@ -9,7 +9,7 @@ describe MarkAsRead do
 
     it "marks a story as read" do
       command = MarkAsRead.new(1, repo)
-      expect(story).to receive(:update_attributes).with(is_read: true)
+      expect(story).to receive(:update).with(is_read: true)
       command.mark_as_read
     end
   end

--- a/spec/commands/stories/mark_as_read_spec.rb
+++ b/spec/commands/stories/mark_as_read_spec.rb
@@ -4,13 +4,12 @@ app_require "commands/stories/mark_as_read"
 
 describe MarkAsRead do
   describe "#mark_as_read" do
-    let(:story) { double }
-    let(:repo) { double(fetch: story) }
+    let(:story) { create_story(is_read: false) }
 
     it "marks a story as read" do
-      command = MarkAsRead.new(1, repo)
-      expect(story).to receive(:update).with(is_read: true)
-      command.mark_as_read
+      expect { MarkAsRead.new(story.id).mark_as_read }
+        .to change { Story.find(story.id).is_read }
+        .to(true)
     end
   end
 end

--- a/spec/commands/stories/mark_as_starred_spec.rb
+++ b/spec/commands/stories/mark_as_starred_spec.rb
@@ -9,7 +9,7 @@ describe MarkAsStarred do
 
     it "marks a story as starred" do
       command = MarkAsStarred.new(1, repo)
-      expect(story).to receive(:update_attributes).with(is_starred: true)
+      expect(story).to receive(:update).with(is_starred: true)
       command.mark_as_starred
     end
   end

--- a/spec/commands/stories/mark_as_starred_spec.rb
+++ b/spec/commands/stories/mark_as_starred_spec.rb
@@ -4,13 +4,12 @@ app_require "commands/stories/mark_as_starred"
 
 describe MarkAsStarred do
   describe "#mark_as_starred" do
-    let(:story) { double }
-    let(:repo) { double(fetch: story) }
+    let(:story) { create_story(is_starred: false) }
 
     it "marks a story as starred" do
-      command = MarkAsStarred.new(1, repo)
-      expect(story).to receive(:update).with(is_starred: true)
-      command.mark_as_starred
+      expect { MarkAsStarred.new(story.id).mark_as_starred }
+        .to change { Story.find(story.id).is_starred }
+        .to(true)
     end
   end
 end

--- a/spec/commands/stories/mark_as_unread_spec.rb
+++ b/spec/commands/stories/mark_as_unread_spec.rb
@@ -9,7 +9,7 @@ describe MarkAsUnread do
 
     it "marks a story as unread" do
       command = MarkAsUnread.new(1, repo)
-      expect(story).to receive(:update_attributes).with(is_read: false)
+      expect(story).to receive(:update).with(is_read: false)
       command.mark_as_unread
     end
   end

--- a/spec/commands/stories/mark_as_unread_spec.rb
+++ b/spec/commands/stories/mark_as_unread_spec.rb
@@ -4,13 +4,12 @@ app_require "commands/stories/mark_as_unread"
 
 describe MarkAsUnread do
   describe "#mark_as_unread" do
-    let(:story) { double }
-    let(:repo) { double(fetch: story) }
+    let(:story) { create_story(is_read: true) }
 
     it "marks a story as unread" do
-      command = MarkAsUnread.new(1, repo)
-      expect(story).to receive(:update).with(is_read: false)
-      command.mark_as_unread
+      expect { MarkAsUnread.new(story.id).mark_as_unread }
+        .to change { Story.find(story.id).is_read }
+        .to(false)
     end
   end
 end

--- a/spec/commands/stories/mark_as_unstarred_spec.rb
+++ b/spec/commands/stories/mark_as_unstarred_spec.rb
@@ -9,7 +9,7 @@ describe MarkAsUnstarred do
 
     it "marks a story as unstarred" do
       command = MarkAsUnstarred.new(1, repo)
-      expect(story).to receive(:update_attributes).with(is_starred: false)
+      expect(story).to receive(:update).with(is_starred: false)
       command.mark_as_unstarred
     end
   end

--- a/spec/commands/stories/mark_as_unstarred_spec.rb
+++ b/spec/commands/stories/mark_as_unstarred_spec.rb
@@ -4,13 +4,12 @@ app_require "commands/stories/mark_as_unstarred"
 
 describe MarkAsUnstarred do
   describe "#mark_as_unstarred" do
-    let(:story) { double }
-    let(:repo) { double(fetch: story) }
+    let(:story) { create_story(is_starred: true) }
 
     it "marks a story as unstarred" do
-      command = MarkAsUnstarred.new(1, repo)
-      expect(story).to receive(:update).with(is_starred: false)
-      command.mark_as_unstarred
+      expect { MarkAsUnstarred.new(story.id).mark_as_unstarred }
+        .to change { Story.find(story.id).is_starred }
+        .to(false)
     end
   end
 end


### PR DESCRIPTION
This will replace the method `update_attributes` that was removed in ActiveRecord 6.1. 

Fixes #612