### PR TITLE
Errors: add activesupport dependency

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,7 @@
 require "rubygems"
 require "bundler"
 
+require "active_support/core_ext/kernel/reporting"
 Bundler.require
 
 require "./fever_api"


### PR DESCRIPTION
This adds `activesupport` as a dependency and requires
`active_support/all`. This should (hopefully) fix [this issue][is] where
an error is thrown when loading `Delayed::Job`.

[is]: https://github.com/stringer-rss/stringer/issues/644
