### PR TITLE
update links and branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Stringer
 
 [![CircleCI](https://circleci.com/gh/stringer-rss/stringer/tree/main.svg?style=svg)](https://circleci.com/gh/stringer-rss/stringer/tree/main)
-[![Code Climate](https://codeclimate.com/github/swanson/stringer.svg?style=flat)](https://codeclimate.com/github/swanson/stringer)
-[![Coverage Status](https://coveralls.io/repos/swanson/stringer/badge.svg?style=flat)](https://coveralls.io/r/swanson/stringer)
+[![Code Climate](https://api.codeclimate.com/v1/badges/899c5407c870e541af4e/maintainability)](https://codeclimate.com/github/stringer-rss/stringer/maintainability)
+[![Coverage Status](https://coveralls.io/repos/github/stringer-rss/stringer/badge.svg?branch=main)](https://coveralls.io/github/stringer-rss/stringer?branch=main)
 
 ### A self-hosted, anti-social RSS reader.
 
@@ -128,6 +128,9 @@ If you have a question, feature idea, or are running into problems, our preferre
 
 ## Maintainers
 
-Matt Swanson, [mdswanson.com](http://mdswanson.com), [@_swanson](http://twitter.com/_swanson)
+Robert Fletcher [boon.gl](https://boon.gl)
 
+## Alumni
+
+Matt Swanson (creator), [mdswanson.com](http://mdswanson.com), [@_swanson](http://twitter.com/_swanson)
 Victor Koronen, [victor.koronen.se](http://victor.koronen.se/), [@victorkoronen](https://twitter.com/victorkoronen)

--- a/app.json
+++ b/app.json
@@ -1,12 +1,12 @@
 {
   "name": "Stringer",
   "description": "A self-hosted, anti-social RSS reader.",
-  "logo": "https://raw.githubusercontent.com/swanson/stringer/master/screenshots/logo.png",
+  "logo": "https://raw.githubusercontent.com/stringer-rss/stringer/main/screenshots/logo.png",
   "keywords": [
     "RSS",
     "Ruby"
   ],
-  "website": "https://github.com/swanson/stringer",
+  "website": "https://github.com/stringer-rss/stringer",
   "success_url": "/heroku",
   "scripts": {
     "postdeploy": "bundle exec rake db:migrate"

--- a/app.rb
+++ b/app.rb
@@ -19,7 +19,7 @@ I18n.load_path += Dir[File.join(File.dirname(__FILE__), "config/locales", "*.yml
 I18n.config.enforce_available_locales = false
 
 class Stringer < Sinatra::Base
-  # need to exclude assets for sinatra assetpack, see https://github.com/swanson/stringer/issues/112
+  # need to exclude assets for sinatra assetpack, see https://github.com/stringer-rss/stringer/issues/112
   use Rack::SSL, exclude: ->(env) { env["PATH_INFO"] =~ %r{^/(js|css|img)} } if ENV["ENFORCE_SSL"] == "true"
 
   register Sinatra::ActiveRecordExtension

--- a/app/views/partials/_footer.erb
+++ b/app/views/partials/_footer.erb
@@ -13,7 +13,7 @@
           <li class="muted">·</li>
         <% end %>
 
-        <li><a href="https://github.com/swanson/stringer"><%= t('layout.support') %></a></li>
+        <li><a href="https://github.com/stringer-rss/stringer"><%= t('layout.support') %></a></li>
       </ul>
     </div>
     <div class="span6">

--- a/docs/Heroku.md
+++ b/docs/Heroku.md
@@ -1,8 +1,8 @@
 ```sh
-git clone git://github.com/swanson/stringer.git
+git clone git@github.com:stringer-rss/stringer.git
 cd stringer
 heroku create
-git push heroku master
+git push heroku main
 
 heroku config:set APP_URL=`heroku apps:info --shell | grep web_url | cut -d= -f2`
 heroku config:set SECRET_TOKEN=`openssl rand -hex 20`
@@ -26,7 +26,7 @@ From the app's directory:
 
 ```sh
 git pull
-git push heroku master
+git push heroku main
 heroku run rake db:migrate
 heroku restart
 ```

--- a/docs/OpenShift.md
+++ b/docs/OpenShift.md
@@ -14,8 +14,8 @@ Deploying into OpenShift
 
  ```sh
 	cd feeds
-	git remote add upstream git://github.com/swanson/stringer.git
-	git pull -s recursive -X theirs upstream master
+	git remote add upstream git@github.com:stringer-rss/stringer.git
+	git pull -s recursive -X theirs upstream main
  ```
 
 3. To enable migrations for the application, a new action_hook is required. Add the file, .openshift/action_hooks/deploy,  with the below 3 lines into it.

--- a/docs/VPS.md
+++ b/docs/VPS.md
@@ -79,7 +79,7 @@ Install Stringer and set it up
 
 Grab Stringer from github
 
-    git clone https://github.com/swanson/stringer.git
+    git clone git@github.com:stringer-rss/stringer.git
     cd stringer
 
 Use bundler to grab and build Stringer's dependencies

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -40,7 +40,7 @@ docker run --detach \
     -e FETCH_FEEDS_CRON="*/5 * * * *" \ # optional
     -e CLEANUP_CRON="0 0 * * *" \ # optional
     -p 127.0.0.1:8080:8080 \
-    mdswanson/stringer
+    stringer-rss/stringer
 ```
 
 That's it! You now have a fully working Stringer instance up and running!

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -44,7 +44,7 @@ describe "StoriesController" do
       page = last_response.body
       expect(page).to have_tag("a", with: { href: "/feeds/export" })
       expect(page).to have_tag("a", with: { href: "/logout" })
-      expect(page).to have_tag("a", with: { href: "https://github.com/swanson/stringer" })
+      expect(page).to have_tag("a", with: { href: "https://github.com/stringer-rss/stringer" })
     end
 
     it "displays a zen-like message when there are no unread stories" do

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -369,16 +369,16 @@ describe StoryRepository do
   describe ".extract_url" do
     it "returns the url" do
       feed = double(url: "http://github.com")
-      entry = double(url: "https://github.com/swanson/stringer")
+      entry = double(url: "https://github.com/stringer-rss/stringer")
 
-      expect(StoryRepository.extract_url(entry, feed)).to eq "https://github.com/swanson/stringer"
+      expect(StoryRepository.extract_url(entry, feed)).to eq "https://github.com/stringer-rss/stringer"
     end
 
     it "returns the enclosure_url when the url is nil" do
       feed = double(url: "http://github.com")
-      entry = double(url: nil, enclosure_url: "https://github.com/swanson/stringer")
+      entry = double(url: nil, enclosure_url: "https://github.com/stringer-rss/stringer")
 
-      expect(StoryRepository.extract_url(entry, feed)).to eq "https://github.com/swanson/stringer"
+      expect(StoryRepository.extract_url(entry, feed)).to eq "https://github.com/stringer-rss/stringer"
     end
 
     it "does not crash if url is nil but enclosure_url does not exist" do


### PR DESCRIPTION
Update GitHub links to point to `stringer-rss/stringer` and rename
`master` to `main`.
