### PR TITLE
update deploy button link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ But it does have keyboard shortcuts and was made with love!
 
 Stringer is a Ruby app based on Sinatra, ActiveRecord, PostgreSQL, Backbone.js and DelayedJob.
 
-[![Deploy to Heroku](https://cdn.herokuapp.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy to Heroku](https://cdn.herokuapp.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stringer-rss/stringer)
 
 Stringer will run just fine on the Heroku free plan.
 


### PR DESCRIPTION
For some reason it doesn't work without the `template` param for me.
Maybe I'm using a privacy extension that strips out the `referer`.
Explicitly passing the `template` will provide a more reliable
experience, even if it's a little less flexible, as forks will no longer
be able to be deployed as easily.
