### PR TITLE
Add download link when story has enclosure

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -184,6 +184,7 @@ Lint/ConstantResolution:
     - 'db/migrate/20140413100725_add_groups_table_and_foreign_keys_to_feeds.rb'
     - 'db/migrate/20140421224454_fix_invalid_unicode.rb'
     - 'db/migrate/20141102103617_fix_invalid_titles_with_unicode_line_endings.rb'
+    - 'db/migrate/20221206231914_add_enclosure_url_to_stories.rb'
     - 'fever_api.rb'
     - 'spec/commands/feeds/add_new_feed_spec.rb'
     - 'spec/commands/feeds/export_to_opml_spec.rb'

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -207,7 +207,7 @@ li.story.open .story-preview {
   margin-left: 20px;
 }
 
-.story-keep-unread, .story-starred  {
+.story-keep-unread, .story-starred, .story-enclosure {
   display: inline-block;
   cursor: pointer;
   -webkit-touch-callout: none;

--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -7,9 +7,11 @@ class StoryRepository
   extend UrlHelpers
 
   def self.add(entry, feed)
+    enclosure_url = entry.enclosure_url if entry.respond_to?(:enclosure_url)
     Story.create(feed: feed,
                  title: extract_title(entry),
                  permalink: extract_url(entry, feed),
+                 enclosure_url: enclosure_url,
                  body: extract_content(entry),
                  is_read: false,
                  is_starred: false,

--- a/app/views/js/templates/_story.js.erb
+++ b/app/views/js/templates/_story.js.erb
@@ -38,6 +38,11 @@
         <div class="story-starred">
           <i class="icon-star{{ if(!is_starred) { }}-empty{{ } }}"></i>
         </div>
+        {{ if (enclosure_url) { }}
+          <a class="story-enclosure" target="_blank" href="{{= enclosure_url }}">
+            <i class="icon-download"></i>
+          </a>
+        {{ } }}
         <a class="story-permalink" target="_blank" href="{{= permalink }}">
           <i class="icon-external-link"></i>
         </a>

--- a/db/migrate/20221206231914_add_enclosure_url_to_stories.rb
+++ b/db/migrate/20221206231914_add_enclosure_url_to_stories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEnclosureUrlToStories < ActiveRecord::Migration[4.2]
+  def change
+    add_column(:stories, :enclosure_url, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2014_11_02_103617) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_12_06_231914) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -59,6 +58,7 @@ ActiveRecord::Schema.define(version: 2014_11_02_103617) do
     t.boolean "keep_unread", default: false
     t.boolean "is_starred", default: false
     t.text "entry_id"
+    t.string "enclosure_url"
     t.index ["entry_id", "feed_id"], name: "index_stories_on_entry_id_and_feed_id", unique: true
   end
 

--- a/spec/javascript/spec/views/story_view_spec.js
+++ b/spec/javascript/spec/views/story_view_spec.js
@@ -9,6 +9,7 @@ describe("Storyiew", function(){
     before(function() {
       this.story = new Story({
         source: "TechKrunch",
+        enclosure_url: null,
         headline: "Every startups acquired by Yahoo!",
         lead: "This is the lead.",
         title: "Every startups acquired by Yahoo! NOT!!",
@@ -32,6 +33,10 @@ describe("Storyiew", function(){
     var assertTagExists = function(el, tagName, count) {
       count = typeof count !== "undefined" ? count : 1;
       el.find(tagName).should.have.length(count);
+    };
+
+    var assertNoTagExists = function(el, tagName) {
+      el.find(tagName).should.have.length(0);
     };
 
     var assertPropertyRendered = function(el, model, propName) {
@@ -102,6 +107,18 @@ describe("Storyiew", function(){
       this.view.render();
 
       assertTagExists(this.view.$el, ".story-starred .icon-star", 2);
+    });
+
+    it("should not render enclosure link when not present", function(){
+      assertNoTagExists(this.view.$el, ".story-enclosure");
+    });
+
+    it("should render enclosure link when present", function(){
+      this.story.set("enclosure_url", "http://example.com/enclosure");
+      this.view.render();
+
+      assertTagExists(this.view.$el, ".story-enclosure");
+      assertPropertyRendered(this.view.$el, this.story, "enclosure_url");
     });
 
     describe("Handling click on story", function(){

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -85,6 +85,7 @@ describe "Story" do
       expect(story.as_json).to eq({
         body: "story body",
         created_at: created_at.utc.as_json,
+        enclosure_url: nil,
         entry_id: "5",
         feed_id: feed.id,
         headline: "the story title",

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -34,6 +34,28 @@ describe StoryRepository do
 
       StoryRepository.add(entry, feed)
     end
+
+    it "sets the enclosure url when present" do
+      entry = instance_double(Feedjira::Parser::ITunesRSSItem,
+                              enclosure_url: "http://example.com/audio.mp3",
+                              title: "",
+                              summary: "",
+                              content: "").as_null_object
+      allow(StoryRepository).to receive(:normalize_url)
+
+      expect(Story).to receive(:create).with(hash_including(enclosure_url: "http://example.com/audio.mp3"))
+
+      StoryRepository.add(entry, feed)
+    end
+
+    it "does not set the enclosure url when not present" do
+      entry = instance_double(Feedjira::Parser::RSSEntry, title: "", summary: "", content: "").as_null_object
+      allow(StoryRepository).to receive(:normalize_url)
+
+      expect(Story).to receive(:create).with(hash_including(enclosure_url: nil))
+
+      StoryRepository.add(entry, feed)
+    end
   end
 
   describe ".fetch" do


### PR DESCRIPTION
Many podcast and other media feeds have both a `url` and an
`enclosure_url`. For example, [the Welcome to Nightvale feed][wn]. In
these cases, there's a good chance the user might want to get straight
to the enclosure rather than being directed to another site to listen to
the track. This allows us to directly download the enclosure rather than
having to hunt it down somewhere else.

[wn]: http://feeds.nightvalepresents.com/welcometonightvalepodcast