### PR TITLE
Deps: add a `.tool-versions` file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+ruby 3.1.3
+bundler 2.2.33
+postgres 14.6


### PR DESCRIPTION
This file allows us to use tools like [`asdf`][asdf] to manage a wide
variety of application dependencies.

[asdf]: https://github.com/asdf-vm/asdf
