### PR TITLE
Deps: update bundler version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 3.1.3
-bundler 2.2.33
+bundler 2.3.25
 postgres 14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,4 +245,4 @@ RUBY VERSION
    ruby 3.1.3
 
 BUNDLED WITH
-   2.2.33
+   2.3.25


### PR DESCRIPTION
This updates our bundler version to match the latest version [currently
supported by Heroku][he].

[he]: https://devcenter.heroku.com/articles/ruby-support#libraries
