### PR TITLE
Move enclosure download link to the heading

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -207,7 +207,11 @@ li.story.open .story-preview {
   margin-left: 20px;
 }
 
-.story-keep-unread, .story-starred, .story-enclosure {
+.story-enclosure {
+  float: right;
+}
+
+.story-keep-unread, .story-starred {
   display: inline-block;
   cursor: pointer;
   -webkit-touch-callout: none;

--- a/app/views/js/templates/_story.js.erb
+++ b/app/views/js/templates/_story.js.erb
@@ -22,7 +22,14 @@
 
   <div class="story-body-container" class="row-fluid">
     <div class="story-body">
-      <h1><a href="{{= permalink }}">{{= title }}</a></h1>
+      <h1>
+        <a href="{{= permalink }}">{{= title }}</a>
+        {{ if (enclosure_url) { }}
+          <a class="story-enclosure" target="_blank" href="{{= enclosure_url }}">
+            <i class="icon-download"></i>
+          </a>
+        {{ } }}
+      </h1>
       {{= body }}
     </div>
     <div class="row-fluid story-actions-container">
@@ -38,11 +45,6 @@
         <div class="story-starred">
           <i class="icon-star{{ if(!is_starred) { }}-empty{{ } }}"></i>
         </div>
-        {{ if (enclosure_url) { }}
-          <a class="story-enclosure" target="_blank" href="{{= enclosure_url }}">
-            <i class="icon-download"></i>
-          </a>
-        {{ } }}
         <a class="story-permalink" target="_blank" href="{{= permalink }}">
           <i class="icon-external-link"></i>
         </a>


### PR DESCRIPTION
It's kind of a pain to hunt down the download link all the way at the
bottom, especially in cases where the body is longer.
