### PR TITLE
Set timezone in app.rb

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -17,6 +17,7 @@ require_relative "config/asset_pipeline"
 
 I18n.load_path += Dir[File.join(File.dirname(__FILE__), "config/locales", "*.yml").to_s]
 I18n.config.enforce_available_locales = false
+Time.zone = ENV.fetch("TZ", "UTC")
 
 class Stringer < Sinatra::Base
   # need to exclude assets for sinatra assetpack, see https://github.com/stringer-rss/stringer/issues/112


### PR DESCRIPTION
This sets `Time.zone` inside `app.rb`. Currently it isn't set, which
causes `delayed_job_active_record` to [go down a deprecated path][dj].
`ActiveRecord#default_timezone` is deprecated and will be removed in
Rails 7.1, so setting the timezone avoids this issue and punts the
problem of an outdated queueing system down the road.

[dj]: https://github.com/collectiveidea/delayed_job_active_record/blob/d65b0f9900f5b0c78c341c7c0209c2d138d64ec5/lib/delayed/backend/active_record.rb#L175
