### PR TITLE
Security: always enforce SSL

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -21,7 +21,7 @@ Time.zone = ENV.fetch("TZ", "UTC")
 
 class Stringer < Sinatra::Base
   # need to exclude assets for sinatra assetpack, see https://github.com/stringer-rss/stringer/issues/112
-  use Rack::SSL, exclude: ->(env) { env["PATH_INFO"] =~ %r{^/(js|css|img)} } if ENV["ENFORCE_SSL"] == "true"
+  use Rack::SSL, exclude: ->(env) { env["PATH_INFO"] =~ %r{^/(js|css|img)} }
 
   register Sinatra::ActiveRecordExtension
   register Sinatra::Flash

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,19 @@ require "./app"
 
 Capybara.server = :puma, { Silent: true }
 
+module Rack
+  module Test
+    class Session
+      alias old_custom_request custom_request
+
+      def custom_request(method, path, params = {}, env = {}, &)
+        env["HTTPS"] = "on"
+        old_custom_request(method, path, params, env, &)
+      end
+    end
+  end
+end
+
 RSpec.configure do |config|
   config.include Rack::Test::Methods
   config.include RSpecHtmlMatchers


### PR DESCRIPTION
I had to add a monkey patch for `Rack::Test` as they don't seem to have
a good way to enable SSL by default otherwise.
