### PR TITLE
Security: enforce SSL in tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 ENV["RACK_ENV"] = "test"
+ENV["ENFORCE_SSL"] = "true"
 
 require "capybara"
 require "capybara/server"
@@ -16,6 +17,19 @@ require_relative "factories"
 require "./app"
 
 Capybara.server = :puma, { Silent: true }
+
+module Rack
+  module Test
+    class Session
+      alias old_custom_request custom_request
+
+      def custom_request(method, path, params = {}, env = {}, &)
+        env["HTTPS"] = "on"
+        old_custom_request(method, path, params, env, &)
+      end
+    end
+  end
+end
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods


### PR DESCRIPTION
I had to add a monkey patch for `Rack::Test` as they don't seem to have
a good way to enable SSL by default otherwise.
