### PR TITLE
fix debug page

### DIFF
--- a/app/models/migration_status.rb
+++ b/app/models/migration_status.rb
@@ -1,17 +1,13 @@
 class MigrationStatus
   attr_reader :migrator
 
-  def initialize(migrator = ActiveRecord::Migrator)
+  def initialize(migrator = ActiveRecord::Base.connection.migration_context.open)
     @migrator = migrator
   end
 
   def pending_migrations
-    migrations_path = migrator.migrations_path
-    migrations = migrator.migrations(migrations_path)
-    current_version = migrator.current_version
-
-    migrations
-      .select { |m| current_version < m.version }
-      .map { |m| "#{m.name} - #{m.version}" }
+    migrator.pending_migrations.map do |migration|
+      "#{migration.name} - #{migration.version}"
+    end
   end
 end

--- a/spec/models/migration_status_spec.rb
+++ b/spec/models/migration_status_spec.rb
@@ -6,14 +6,14 @@ app_require "models/migration_status"
 describe "MigrationStatus" do
   describe "pending_migrations" do
     it "returns array of strings representing pending migrations" do
-      migrator = double "Migrator"
-      allow(migrator).to receive(:migrations).and_return [
-        double("First Migration", name: "Migration A", version: 1),
-        double("Second Migration", name: "Migration B", version: 2),
-        double("Third Migration", name: "Migration C", version: 3)
-      ]
-      allow(migrator).to receive(:migrations_path)
-      allow(migrator).to receive(:current_version).and_return 1
+      migrator = ActiveRecord::Base.connection.migration_context.open
+
+      allow(migrator).to receive(:pending_migrations).and_return(
+        [
+          ActiveRecord::Migration.new("Migration B", 2),
+          ActiveRecord::Migration.new("Migration C", 3)
+        ]
+      )
 
       expect(MigrationStatus.new(migrator).pending_migrations)
         .to eq(["Migration B - 2", "Migration C - 3"])


### PR DESCRIPTION
The mocking hid the fact that the migration methods were no longer
available, so I updated the tests to use the actual classes.

`ActiveRecord::Base.connection.migration_context.open` always returns a
new instance, so for now we continue passing it down in order to avoid
needing to use `allow_any_instance_of`.
