### PR TITLE
Rails: fix issue with Delayed::Job

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1034,6 +1034,7 @@ Style/NumericPredicate:
 # Offense count: 4
 Style/OpenStructUse:
   Exclude:
+    - 'app.rb'
     - 'spec/factories/feed_factory.rb'
     - 'spec/factories/group_factory.rb'
     - 'spec/factories/story_factory.rb'

--- a/app.rb
+++ b/app.rb
@@ -23,6 +23,12 @@ require_relative "app/controllers/application_controller"
 require_relative "app/controllers/debug_controller"
 require_relative "app/controllers/feeds_controller"
 
+module Rails
+  def self.application
+    OpenStruct.new(config: OpenStruct.new(cache_classes: true))
+  end
+end
+
 I18n.load_path += Dir[File.join(File.dirname(__FILE__), "config/locales", "*.yml").to_s]
 I18n.config.enforce_available_locales = false
 Time.zone = ENV.fetch("TZ", "UTC")

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -2,6 +2,12 @@ require "spec_helper"
 require "support/active_record"
 
 describe "App" do
+  describe "Rails" do
+    it "returns a fake application" do
+      expect(Rails.application.config.cache_classes).to be(true)
+    end
+  end
+
   context "when user is not authenticated and page requires authentication" do
     it "sets the session redirect_to" do
       create_user(:setup_complete)


### PR DESCRIPTION
Now that we're loading `ActionController` it's also loading
`ActionDispatch`, causing the second case in [this line][tl] to raise an
error. For now we'll stub out `Rails` to prevent it.

[tl]: https://github.com/collectiveidea/delayed_job/blob/5ac5adea8d18325d0470eeebfa81227b1f5961e3/lib/delayed/worker.rb#L119
