### PR TITLE
Coverage: remove unused clause in importer

### DIFF
--- a/app/commands/feeds/import_from_opml.rb
+++ b/app/commands/feeds/import_from_opml.rb
@@ -14,8 +14,6 @@ class ImportFromOpml
       # for existing feeds. Feeds without groups are in 'Ungrouped' group, we don't
       # create such group and create such feeds with group_id = nil.
       feeds_with_groups.each do |group_name, parsed_feeds|
-        next if parsed_feeds.empty?
-
         group = Group.where(name: group_name).first_or_create unless group_name == "Ungrouped"
 
         parsed_feeds.each { |parsed_feed| create_feed(parsed_feed, group) }

--- a/spec/commands/feeds/import_from_opml_spec.rb
+++ b/spec/commands/feeds/import_from_opml_spec.rb
@@ -29,19 +29,24 @@ describe ImportFromOpml do
         url: "http://feeds.feedburner.com/GiantRobotsSmashingIntoOtherGiantRobots"
       )
     end
-    before { import }
 
     it "retains exising feeds" do
+      described_class.import(subscriptions)
+
       expect(feed1).to be_valid
       expect(feed2).to be_valid
     end
 
     it "creates new groups" do
+      described_class.import(subscriptions)
+
       expect(group1).to be
       expect(group2).to be
     end
 
     it "sets group_id for existing feeds" do
+      described_class.import(subscriptions)
+
       expect(feed1.reload.group).to eq group1
       expect(feed2.reload.group).to eq group2
     end
@@ -57,21 +62,32 @@ describe ImportFromOpml do
         url: "http://feeds.feedburner.com/GiantRobotsSmashingIntoOtherGiantRobots"
       )
     end
-    before { import }
 
     it "creates groups" do
+      described_class.import(subscriptions)
+
       expect(group1).to be
       expect(group1).to be
     end
 
     it "creates feeds" do
+      described_class.import(subscriptions)
+
       expect(feed1).to exist
       expect(feed2).to exist
     end
 
     it "sets group" do
+      described_class.import(subscriptions)
+
       expect(feed1.first.group).to eq group1
       expect(feed2.first.group).to eq group2
+    end
+
+    it "does not create empty group" do
+      described_class.import(subscriptions)
+
+      expect(Group.find_by_name("Empty Group")).to be_nil
     end
   end
 
@@ -79,13 +95,15 @@ describe ImportFromOpml do
     let(:feed1) { Feed.where(name: "Autoblog", url: "http://feeds.autoblog.com/weblogsinc/autoblog/").first }
     let(:feed2) { Feed.where(name: "City Guide News", url: "http://www.probki.net/news/RSS_news_feed.asp").first }
 
-    before { import }
-
     it "does not create any new group for feeds without group" do
+      described_class.import(subscriptions)
+
       expect(Group.where("id NOT IN (?)", [group1.id, group2.id]).count).to eq 0
     end
 
     it "creates feeds without group_id" do
+      described_class.import(subscriptions)
+
       expect(feed1.group_id).to be_nil
       expect(feed2.group_id).to be_nil
     end

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -13,4 +13,4 @@ SimpleCov.start(:rails) do
   add_group("Utils", "app/utils")
   enable_coverage :branch
 end
-SimpleCov.minimum_coverage(line: 100, branch: 91)
+SimpleCov.minimum_coverage(line: 100, branch: 99)

--- a/spec/support/files/subscriptions.xml
+++ b/spec/support/files/subscriptions.xml
@@ -23,5 +23,7 @@
             <outline text="igvita.com" title="igvita.com" type="rss"
                 xmlUrl="http://www.igvita.com/feed/" htmlUrl="http://www.igvita.com"/>
         </outline>
+        <outline title="Empty Group" text="Empty Group">
+        </outline>
     </body>
 </opml>


### PR DESCRIPTION
Based on the implementation of `OpmlParser` it doesn't look like there's
any way to hit this guard clause.
