### PR TITLE
Fix: handle feeds that are missing a title

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -216,6 +216,7 @@ RSpec/EmptyLineAfterHook:
 # Configuration parameters: Max, CountAsOne.
 RSpec/ExampleLength:
   Exclude:
+    - 'spec/commands/feeds/add_new_feed_spec.rb'
     - 'spec/commands/feeds/export_to_opml_spec.rb'
     - 'spec/commands/find_new_stories_spec.rb'
     - 'spec/controllers/first_run_controller_spec.rb'

--- a/app/commands/feeds/add_new_feed.rb
+++ b/app/commands/feeds/add_new_feed.rb
@@ -9,10 +9,8 @@ class AddNewFeed
     result = discoverer.discover(url)
     return false unless result
 
-    repo.create(
-      name: ContentSanitizer.sanitize(result.title),
-      url: result.feed_url,
-      last_fetched: Time.now - ONE_DAY
-    )
+    name = ContentSanitizer.sanitize(result.title.presence || result.feed_url)
+
+    repo.create(name:, url: result.feed_url, last_fetched: Time.now - ONE_DAY)
   end
 end

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative "../repositories/feed_repository"
+require_relative "../commands/feeds/add_new_feed"
+require_relative "../commands/feeds/export_to_opml"
+
 class FeedsController < ApplicationController
   def index
     @feeds = FeedRepository.list

--- a/spec/commands/feeds/add_new_feed_spec.rb
+++ b/spec/commands/feeds/add_new_feed_spec.rb
@@ -45,5 +45,16 @@ describe AddNewFeed do
         end
       end
     end
+
+    it "uses feed_url as name when title is not present" do
+      feed_url = "https://protomen.com/news/feed"
+      result = instance_double(Feedjira::Parser::RSS, title: nil, feed_url:)
+      discoverer = instance_double(FeedDiscovery, discover: result)
+
+      expect { AddNewFeed.add(feed_url, discoverer) }
+        .to change(Feed, :count).by(1)
+
+      expect(Feed.last.name).to eq(feed_url)
+    end
   end
 end


### PR DESCRIPTION
Use the URL in its place.

Fixes #744.
