### PR TITLE
Specs: set up Webmock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,4 +46,5 @@ group :development, :test do
   gem "shotgun"
   gem "simplecov"
   gem "timecop"
+  gem "webmock", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       term-ansicolor (~> 1.7)
       thor (~> 1.2)
       tins (~> 1.32)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     date (3.3.3)
     delayed_job (4.1.11)
@@ -114,6 +116,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -301,6 +304,10 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.3.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -348,6 +355,7 @@ DEPENDENCIES
   thread
   timecop
   uglifier
+  webmock
   will_paginate
 
 RUBY VERSION

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ require "date"
 
 require_relative "support/coverage"
 require_relative "support/factory_bot"
+require_relative "support/webmock"
 require_relative "factories"
 
 require "./app"

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "webmock/rspec"
+
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: [/geckodriver/, /chromedriver/]
+)


### PR DESCRIPTION
Prevent network connections. It's really easily to accidentally invoke
the `FeedDiscovery` class, which hits the network, so this will make
sure we don't forget.
