### PR TITLE
Rails: switch api_key to has_secure_token

### DIFF
--- a/app/commands/users/change_user_password.rb
+++ b/app/commands/users/change_user_password.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "../../repositories/user_repository"
-require_relative "../../utils/api_key"
 
 class ChangeUserPassword
   def initialize(repository = UserRepository)
@@ -11,7 +10,7 @@ class ChangeUserPassword
   def change_user_password(new_password)
     user = @repo.first
     user.password = user.password_confirmation = new_password
-    user.api_key = ApiKey.compute(new_password)
+    user.regenerate_api_key
 
     @repo.save(user)
     user

--- a/app/commands/users/create_user.rb
+++ b/app/commands/users/create_user.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../utils/api_key"
-
 class CreateUser
   def self.call(password)
     new.call(password)
@@ -13,10 +11,6 @@ class CreateUser
 
   def call(password)
     @repo.delete_all
-    @repo.create(
-      password:,
-      password_confirmation: password,
-      api_key: ApiKey.compute(password)
-    )
+    @repo.create(password:, password_confirmation: password)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,5 @@ require_relative "./application_record"
 
 class User < ApplicationRecord
   has_secure_password
+  has_secure_token :api_key
 end

--- a/app/utils/api_key.rb
+++ b/app/utils/api_key.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "digest/md5"
-
-class ApiKey
-  def self.compute(plaintext_password)
-    Digest::MD5.hexdigest("stringer:#{plaintext_password}")
-  end
-end

--- a/spec/commands/users/change_user_password_spec.rb
+++ b/spec/commands/users/change_user_password_spec.rb
@@ -28,9 +28,8 @@ describe ChangeUserPassword do
       expect(repo).to receive(:save)
 
       command = described_class.new(repo)
-      result = command.change_user_password(new_password)
-
-      expect(result.api_key).to eq(ApiKey.compute(new_password))
+      expect  { command.change_user_password(new_password) }
+        .to change(user, :api_key)
     end
   end
 end


### PR DESCRIPTION
MD5 isn't a stellar option for secure hashing, so you may want to
regenerate your api key after this change. We can instead use
`has_secure_token` to generate a random token rather than hashing based
on the password.
