### PR TITLE
Fix typo in docker compose documentation

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -2,7 +2,7 @@
 
 ## Production ready setup using docker-compose
 
-Download [docker-compose.yml](../docker-compose.yml) and in the corresponding foler, run `docker-compose up -d`, give it a second and visit `localhost`
+Download [docker-compose.yml](../docker-compose.yml) and in the corresponding folder, run `docker-compose up -d`, give it a second and visit `localhost`
 
 ## Production ready manual setup
 


### PR DESCRIPTION
Fix a small typo (`foler` to `folder`).