### PR TITLE
Fever: use last feed update for timestamp

### DIFF
--- a/app/fever_api/authentication.rb
+++ b/app/fever_api/authentication.rb
@@ -7,7 +7,9 @@ module FeverAPI
     end
 
     def call(_params)
-      { auth: 1, last_refreshed_on_time: @clock.now.to_i }
+      last_refreshed_on_time = (Feed.maximum(:last_fetched) || 0).to_i
+
+      { auth: 1, last_refreshed_on_time: }
     end
   end
 end

--- a/spec/fever_api/authentication_spec.rb
+++ b/spec/fever_api/authentication_spec.rb
@@ -5,10 +5,22 @@ require "spec_helper"
 app_require "fever_api/authentication"
 
 describe FeverAPI::Authentication do
+  it "returns the latest feed's last_fetched time" do
+    feed = create(:feed, last_fetched: 1.month.ago)
+    create(:feed, last_fetched: 1.year.ago)
+
+    result = described_class.new.call({})
+    expect(result[:last_refreshed_on_time]).to eq(Integer(feed.last_fetched))
+  end
+
+  it "returns 0 for last_refreshed_on_time when there are no feeds" do
+    result = described_class.new.call({})
+    expect(result[:last_refreshed_on_time]).to eq(0)
+  end
+
   it "returns a hash with keys :auth and :last_refreshed_on_time" do
     fake_clock = double("clock")
-    expect(fake_clock).to receive(:now).and_return(1_234_567_890)
     result = described_class.new(clock: fake_clock).call(double)
-    expect(result).to eq(auth: 1, last_refreshed_on_time: 1_234_567_890)
+    expect(result).to eq(auth: 1, last_refreshed_on_time: 0)
   end
 end

--- a/spec/fever_api_spec.rb
+++ b/spec/fever_api_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe FeverAPI, type: :controller do
   def standard_answer
-    { api_version: 3, auth: 1, last_refreshed_on_time: 123_456_789 }
+    { api_version: 3, auth: 1, last_refreshed_on_time: 0 }
   end
 
   def cannot_auth


### PR DESCRIPTION
Per [the docs][do], `last_refreshed_on_time` is the most recently
refreshed feed timestamp. I default it to 0 when there are no feeds. I
considered using `nil`, but 0 seemed like it might be more compatible
with clients that don't handle the "no feeds" case gracefully.

[do]: https://github.com/dasmurphy/tinytinyrss-fever-plugin/blob/c4c866021560d9480d50b4258ee31bb50b80fbbc/fever-api.md#authentication
