### PR TITLE
Fixed routing for reeder app

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,8 @@ class Stringer < Sinatra::Base
   end
 
   match("/", to: "stories#index", via: :get)
-  match("/fever", to: "fever#index", via: :get)
-  match("/fever", to: "fever#update", via: :post)
+  match("/fever/?", to: "fever#index", via: :get)
+  match("/fever/?", to: "fever#update", via: :post)
   match("/archive", to: "stories#archived", via: :get)
   match("/debug", to: "debug#index", via: :get)
   match("/feed/:feed_id", to: "feeds#show", via: :get)


### PR DESCRIPTION
Reeder app assumes that the path ends on a `/`, e.g. `http://www.example.com/fever/`. It always adds that `/`.