### PR TITLE
UI: fix tutorial page rendering

### DIFF
--- a/app/utils/sample_story.rb
+++ b/app/utils/sample_story.rb
@@ -35,6 +35,8 @@ SampleStory =
       "#"
     end
 
+    def enclosure_url; end
+
     def lead
       "Tofu shoreditch intelligentsia umami, fashion axe photo booth try-hard"
     end
@@ -68,6 +70,7 @@ SampleStory =
         title:,
         pretty_date: published.strftime("%A, %B %d"),
         body:,
+        enclosure_url:,
         permalink:,
         is_read:,
         is_starred:,


### PR DESCRIPTION
When I added `enclosure_url`, it [broke the sample stories page][br] as
it uses custom structs rather than story instances. This adds
`enclosure_url` to the sample structs as well.

[br]: https://github.com/stringer-rss/stringer/issues/853
