### PR TITLE
Rails: clean up some gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,13 +37,11 @@ end
 group :development, :test do
   gem "capybara"
   gem "coveralls_reborn", require: false
-  gem "factory_bot_rails"
-  gem "faker"
+  gem "factory_bot"
   gem "pry-byebug"
   gem "rspec"
   gem "rspec-html-matchers"
   gem "rspec-rails"
-  gem "shotgun"
   gem "simplecov"
   gem "timecop"
   gem "webmock", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,11 +103,6 @@ GEM
     execjs (2.8.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
-    factory_bot_rails (6.2.0)
-      factory_bot (~> 6.2.0)
-      railties (>= 5.0.0)
-    faker (3.1.1)
-      i18n (>= 1.8.11, < 2)
     feedbag (1.0.0)
       nokogiri (~> 1.8, >= 1.8.2)
     feedjira (3.2.2)
@@ -263,8 +258,6 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     sax-machine (1.3.2)
-    shotgun (0.9.2)
-      rack (>= 1.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -328,8 +321,7 @@ DEPENDENCIES
   coveralls_reborn
   delayed_job
   delayed_job_active_record
-  factory_bot_rails
-  faker
+  factory_bot
   feedbag
   feedjira
   httparty
@@ -347,7 +339,6 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   sass
-  shotgun
   simplecov
   sinatra
   sinatra-activerecord

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -3,15 +3,12 @@
 require "spec_helper"
 
 describe "Story" do
-  let(:story) do
-    Story.new(
-      title: Faker::Lorem.sentence(word_count: 50),
-      body: Faker::Lorem.sentence(word_count: 50)
-    )
-  end
+  let(:story) { build_stubbed(:story) }
 
   describe "#headline" do
     it "truncates to 50 chars" do
+      story = Story.new(title: "a" * 100)
+
       expect(story.headline.size).to eq(50)
     end
 
@@ -28,6 +25,8 @@ describe "Story" do
 
   describe "#lead" do
     it "truncates to 100 chars" do
+      story = Story.new(body: "a" * 1000)
+
       expect(story.lead.size).to eq(100)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ require "rspec"
 require "rspec-html-matchers"
 require "rack/test"
 require "pry"
-require "faker"
 require "ostruct"
 require "date"
 


### PR DESCRIPTION
* `factory_bot_rails` provides Rails generators which we don't need, and
  not much else. We can rely on `factory_bot` instead.

* `shotgun` is used for reloading the server on file changes, which
  Rails provides out of the box.

* `faker` can result in flaky tests, so we can use deterministic data in
  our tests instead.
