### PR TITLE
Capybara: add system spec for account setup

### DIFF
--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -14,7 +14,7 @@
     <div class="control-group">
       <input name="password_confirmation" id="password-confirmation" type="password" />
       <i class="icon-lock field-icon"></i>
-      <label id="confirm-label" class="field-label" for="password_confirmation"><%= t('first_run.password.fields.password_confirmation') %></label>
+      <label id="confirm-label" class="field-label" for="password-confirmation"><%= t('first_run.password.fields.password_confirmation') %></label>
     </div>
 
     <input type="submit" id="submit" class="btn btn-primary pull-right" value="<%= t('first_run.password.fields.next') %>"/>

--- a/spec/system/account_setup_spec.rb
+++ b/spec/system/account_setup_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "account setup", type: :system do
+  it "allows a user to sign up" do
+    visit "/"
+
+    fill_in("Password", with: "my-password")
+    fill_in("Confirm", with: "my-password")
+
+    click_button("Next")
+    expect(page).to have_content("Welcome aboard.")
+  end
+end


### PR DESCRIPTION
Fix the Confirm label to be properly associated with the input.
