### PR TITLE
MultiUsers: introduce Authorization class

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,13 @@
 class ApplicationController < ActionController::Base
   before_action :complete_setup
   before_action :authenticate_user
+  after_action -> { authorization.verify }
 
   private
+
+  def authorization
+    @authorization ||= Authorization.new(current_user)
+  end
 
   def complete_setup
     redirect_to("/setup/password") unless UserRepository.setup_complete?

--- a/app/controllers/debug_controller.rb
+++ b/app/controllers/debug_controller.rb
@@ -7,6 +7,7 @@ class DebugController < ApplicationController
   skip_before_action :authenticate_user, only: [:heroku]
 
   def index
+    authorization.skip
     render(
       locals: {
         queued_jobs_count: Delayed::Job.count,
@@ -15,5 +16,7 @@ class DebugController < ApplicationController
     )
   end
 
-  def heroku; end
+  def heroku
+    authorization.skip
+  end
 end

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -4,7 +4,7 @@ require_relative "../commands/feeds/export_to_opml"
 
 class ExportsController < ApplicationController
   def index
-    xml = ExportToOpml.call(Feed.all)
+    xml = ExportToOpml.call(authorization.scope(Feed.all))
 
     send_data(
       xml,

--- a/app/controllers/fever_controller.rb
+++ b/app/controllers/fever_controller.rb
@@ -9,10 +9,12 @@ class FeverController < ApplicationController
   before_action :authenticate_fever
 
   def index
+    authorization.skip
     render(json: FeverAPI::Response.call(params))
   end
 
   def update
+    authorization.skip
     render(json: FeverAPI::Response.call(params))
   end
 

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class ImportsController < ApplicationController
-  def new; end
+  def new
+    authorization.skip
+  end
 
   def create
+    authorization.skip
     ImportFromOpml.call(params["opml_file"].read, user: current_user)
 
     redirect_to("/setup/tutorial")

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -5,21 +5,29 @@ class PasswordsController < ApplicationController
   skip_before_action :authenticate_user, only: [:new, :create]
   before_action :redirect_if_setup_complete
 
-  def new; end
+  def new
+    authorization.skip
+  end
 
   def create
-    if no_password(params) || password_mismatch?(params)
-      flash.now[:error] = t("first_run.password.flash.passwords_dont_match")
-      render(:new)
-    else
+    authorization.skip
+
+    if valid_password?(params)
       user = CreateUser.call(params[:password])
       session[:user_id] = user.id
 
       redirect_to("/feeds/import")
+    else
+      flash.now[:error] = t("first_run.password.flash.passwords_dont_match")
+      render(:new)
     end
   end
 
   private
+
+  def valid_password?(params)
+    !(no_password(params) || password_mismatch?(params))
+  end
 
   def no_password(params)
     params[:password].nil? || params[:password] == ""

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,9 +3,12 @@
 class SessionsController < ApplicationController
   skip_before_action :authenticate_user, only: [:new, :create]
 
-  def new; end
+  def new
+    authorization.skip
+  end
 
   def create
+    authorization.skip
     user = SignInUser.sign_in(params[:password])
     if user
       session[:user_id] = user.id
@@ -19,6 +22,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    authorization.skip
     flash[:success] = t("sessions.destroy.flash.logged_out_successfully")
     session[:user_id] = nil
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -2,29 +2,31 @@
 
 class StoriesController < ApplicationController
   def index
-    @unread_stories = StoryRepository.unread
+    @unread_stories = authorization.scope(StoryRepository.unread)
   end
 
   def update
     json_params = JSON.parse(request.body.read, symbolize_names: true)
 
-    story = StoryRepository.fetch(params[:id])
+    story = authorization.check(StoryRepository.fetch(params[:id]))
     story.update!(json_params.slice(:is_read, :is_starred, :keep_unread))
 
     head(:no_content)
   end
 
   def mark_all_as_read
-    MarkAllAsRead.call(params[:story_ids])
+    stories = authorization.scope(Story.where(id: params[:story_ids]))
+    MarkAllAsRead.call(stories.ids)
 
     redirect_to("/news")
   end
 
   def archived
-    @read_stories = StoryRepository.read(params[:page])
+    @read_stories = authorization.scope(StoryRepository.read(params[:page]))
   end
 
   def starred
-    @starred_stories = StoryRepository.starred(params[:page])
+    @starred_stories =
+      authorization.scope(StoryRepository.starred(params[:page]))
   end
 end

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -2,7 +2,7 @@
 
 class TutorialsController < ApplicationController
   def index
-    FetchFeeds.enqueue(Feed.all)
+    FetchFeeds.enqueue(authorization.scope(Feed.all))
 
     @sample_stories = StoryRepository.samples
   end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -5,8 +5,11 @@ require_relative "./feed"
 
 class Story < ApplicationRecord
   belongs_to :feed
+  has_one :user, through: :feed
 
   validates_uniqueness_of :entry_id, scope: :feed_id
+
+  delegate :user_id, to: :feed
 
   UNTITLED = "[untitled]"
 

--- a/app/utils/authorization.rb
+++ b/app/utils/authorization.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Authorization
+  attr_accessor :user, :authorized
+
+  class NotAuthorizedError < StandardError; end
+
+  def initialize(user)
+    self.user = user
+    self.authorized = false
+  end
+
+  alias authorized? authorized
+
+  def check(record)
+    raise(NotAuthorizedError) unless [nil, user.id].include?(record.user_id)
+
+    self.authorized = true
+    record
+  end
+
+  def scope(records)
+    self.authorized = true
+    records.left_joins(:user).where(users: { id: [nil, user.id] })
+  end
+
+  def skip
+    self.authorized = true
+  end
+
+  def verify
+    raise(NotAuthorizedError) unless authorized?
+  end
+end

--- a/spec/javascript/test_controller.rb
+++ b/spec/javascript/test_controller.rb
@@ -2,15 +2,18 @@
 
 class TestController < ApplicationController
   def index
+    authorization.skip
     prepend_view_path(test_path("support", "views"))
     render(layout: false, locals: { js_files: })
   end
 
   def spec
+    authorization.skip
     send_file(test_path("spec", *params[:splat]))
   end
 
   def vendor
+    authorization.skip
     send_file(test_path("support", "vendor", *params[:splat]))
   end
 

--- a/spec/requests/feeds_controller_spec.rb
+++ b/spec/requests/feeds_controller_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe FeedsController, type: :request do
 
       expect(response.body).to have_tag("#stories")
     end
+
+    it "raises an error if the feed belongs to another user" do
+      login_as(create(:user))
+      feed = create(:feed)
+
+      expect { get("/feed/#{feed.id}") }
+        .to raise_error(Authorization::NotAuthorizedError)
+    end
   end
 
   describe "#edit" do
@@ -79,9 +87,11 @@ RSpec.describe FeedsController, type: :request do
   describe "#destroy" do
     it "deletes a feed given the id" do
       login_as(default_user)
-      expect(FeedRepository).to receive(:delete).with("123")
+      feed = create(:feed)
 
-      delete "/feeds/123"
+      delete "/feeds/#{feed.id}"
+
+      expect(Feed.find_by(id: feed.id)).to be_nil
     end
   end
 

--- a/spec/requests/stories_controller_spec.rb
+++ b/spec/requests/stories_controller_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe StoriesController, type: :request do
-  let(:story_one) { create(:story) }
-  let(:story_two) { create(:story) }
-  let(:stories) { [story_one, story_two] }
+  let(:story_one) { create(:story, :unread) }
+  let(:story_two) { create(:story, :unread) }
 
   describe "GET /news" do
     def setup
-      expect(StoryRepository).to receive(:unread).and_return(stories)
+      story_one
+      story_two
     end
 
     it "redirects to the setup page when no user exists" do

--- a/spec/utils/authorization_spec.rb
+++ b/spec/utils/authorization_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+RSpec.describe Authorization do
+  describe "#check" do
+    it "raises an error if the record belongs to another user" do
+      user = create(:user)
+      feed = create(:feed)
+
+      expect { described_class.new(user).check(feed) }
+        .to raise_error(Authorization::NotAuthorizedError)
+    end
+
+    describe "when the user owns the record" do
+      it "marks the request as authorized" do
+        feed = create(:feed)
+        authorization = described_class.new(feed.user)
+
+        authorization.check(feed)
+
+        expect(authorization).to be_authorized
+      end
+
+      it "returns the record" do
+        feed = create(:feed)
+        authorization = described_class.new(feed.user)
+
+        expect(authorization.check(feed)).to eq(feed)
+      end
+    end
+
+    describe "when the record has no user" do
+      it "marks the request as authorized" do
+        feed = create(:feed, user: nil)
+        authorization = described_class.new(default_user)
+
+        authorization.check(feed)
+
+        expect(authorization).to be_authorized
+      end
+
+      it "returns the record" do
+        feed = create(:feed, user: nil)
+        authorization = described_class.new(default_user)
+
+        expect(authorization.check(feed)).to eq(feed)
+      end
+    end
+  end
+
+  describe "#scope" do
+    it "returns the records that belong to the user" do
+      feed = create(:feed)
+
+      expect(described_class.new(feed.user).scope(Feed)).to eq([feed])
+    end
+
+    it "returns the records that have no user" do
+      feed = create(:feed, user: nil)
+
+      expect(described_class.new(default_user).scope(Feed)).to eq([feed])
+    end
+
+    it "does not return records that belong to another user" do
+      create(:feed, user: create(:user))
+
+      expect(described_class.new(default_user).scope(Feed)).to be_empty
+    end
+
+    it "marks the request as authorized" do
+      authorization = described_class.new(default_user)
+
+      authorization.scope(Feed)
+
+      expect(authorization).to be_authorized
+    end
+  end
+
+  describe "#skip" do
+    it "marks the request as authorized" do
+      authorization = described_class.new(default_user)
+
+      authorization.skip
+
+      expect(authorization).to be_authorized
+    end
+  end
+
+  describe "#verify" do
+    it "raises an error if the request was not authorized" do
+      authorization = described_class.new(default_user)
+
+      expect { authorization.verify }
+        .to raise_error(Authorization::NotAuthorizedError)
+    end
+
+    it "does not raise an error if the request was authorized" do
+      authorization = described_class.new(default_user)
+      authorization.skip
+
+      expect { authorization.verify }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This will help to ensure we don't expose the wrong data to different
users by raising an error when we forget to authorize an endpoint.
