### PR TITLE
MultiUsers: lookup fever user via api key

### DIFF
--- a/app/controllers/fever_controller.rb
+++ b/app/controllers/fever_controller.rb
@@ -4,9 +4,7 @@ require_relative "../commands/fever_api/response"
 
 class FeverController < ApplicationController
   skip_before_action :complete_setup, only: [:index, :update]
-  skip_before_action :authenticate_user, only: [:index, :update]
   protect_from_forgery with: :null_session, only: [:update]
-  before_action :authenticate_fever
 
   def index
     authorization.skip
@@ -20,13 +18,13 @@ class FeverController < ApplicationController
 
   private
 
-  def authenticate_fever
-    return if keys_match?(User.first.api_key, params[:api_key].to_s)
+  def authenticate_user
+    return if current_user
 
     render(json: { api_version: FeverAPI::API_VERSION, auth: 0 })
   end
 
-  def keys_match?(key_a, key_b)
-    ActiveSupport::SecurityUtils.secure_compare(key_a, key_b)
+  def current_user
+    @current_user ||= User.find_by(api_key: params[:api_key])
   end
 end


### PR DESCRIPTION
Because we are encrypting the api key, it looks it up via the encrypted
hash, preventing timing attacks.
