### PR TITLE
Fever: make stringer the default user

### DIFF
--- a/app/commands/users/create_user.rb
+++ b/app/commands/users/create_user.rb
@@ -11,7 +11,7 @@ class CreateUser
 
   def call(password)
     @repo.create(
-      username: "default-user",
+      username: "stringer",
       password:,
       password_confirmation: password
     )

--- a/db/migrate/20230223231930_add_username_to_users.rb
+++ b/db/migrate/20230223231930_add_username_to_users.rb
@@ -4,7 +4,7 @@ class AddUsernameToUsers < ActiveRecord::Migration[7.0]
   def change
     add_column :users, :username, :string
     add_index :users, :username, unique: true
-    User.first.update!(username: "default-user")
+    User.first.update!(username: "stringer")
     change_column_null :users, :username, false
   end
 end


### PR DESCRIPTION
The current instructions say to use "stringer" as the username for Fever
clients, so we should default the username to match.
