### PR TITLE
RuboCop: fix module nesting 

### DIFF
--- a/app/commands/fever_api.rb
+++ b/app/commands/fever_api.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module FeverAPI
+  API_VERSION = 3
+
+  PARAMS = [
+    :as,
+    :before,
+    :favicons,
+    :feeds,
+    :groups,
+    :id,
+    :items,
+    :links,
+    :mark,
+    :saved_item_ids,
+    :since_id,
+    :unread_item_ids,
+    :with_ids
+  ].freeze
+end

--- a/app/commands/fever_api/response.rb
+++ b/app/commands/fever_api/response.rb
@@ -1,47 +1,24 @@
 # frozen_string_literal: true
 
-module FeverAPI
-  API_VERSION = 3
-
-  PARAMS = [
-    :as,
-    :before,
-    :favicons,
-    :feeds,
-    :groups,
-    :id,
-    :items,
-    :links,
-    :mark,
-    :saved_item_ids,
-    :since_id,
-    :unread_item_ids,
-    :with_ids
+module FeverAPI::Response
+  ACTIONS = [
+    FeverAPI::Authentication,
+    FeverAPI::ReadFeeds,
+    FeverAPI::ReadGroups,
+    FeverAPI::ReadFeedsGroups,
+    FeverAPI::ReadFavicons,
+    FeverAPI::ReadItems,
+    FeverAPI::ReadLinks,
+    FeverAPI::SyncUnreadItemIds,
+    FeverAPI::SyncSavedItemIds,
+    FeverAPI::WriteMarkItem,
+    FeverAPI::WriteMarkFeed,
+    FeverAPI::WriteMarkGroup
   ].freeze
 
-  module Response
-    ACTIONS = [
-      Authentication,
-
-      ReadFeeds,
-      ReadGroups,
-      ReadFeedsGroups,
-      ReadFavicons,
-      ReadItems,
-      ReadLinks,
-
-      SyncUnreadItemIds,
-      SyncSavedItemIds,
-
-      WriteMarkItem,
-      WriteMarkFeed,
-      WriteMarkGroup
-    ].freeze
-
-    def self.call(params)
-      result = { api_version: API_VERSION }
-      ACTIONS.each { |action| result.merge!(action.call(**params)) }
-      result.to_json
-    end
+  def self.call(params)
+    result = { api_version: FeverAPI::API_VERSION }
+    ACTIONS.each { |action| result.merge!(action.call(**params)) }
+    result.to_json
   end
 end


### PR DESCRIPTION
Depending on the test order, it might not find `API_VERSION`.