### PR TITLE
DB: adjust process numbers

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -13,4 +13,4 @@ test:
 production:
   url: <%= ENV["DATABASE_URL"] %>
   encoding: unicode
-  pool: 5
+  pool: <%= Integer(ENV.fetch("DB_POOL", 15)) %>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,7 +6,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 2)
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 


### PR DESCRIPTION
GoodJob is raising errors for lack of db connections and we're getting
memory warnings from Heroku.
