### PR TITLE
Jobs: remove remaining reporting require

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,7 +2,6 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require "active_support/core_ext/kernel/reporting"
 require_relative "config/environment"
 
 run Rails.application


### PR DESCRIPTION
This was needed due to an issue with Delayed::Job.
