### PR TITLE
Jobs: don't preserve job records

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+GoodJob.preserve_job_records = false


### PR DESCRIPTION
It turns out we generate *a lot* of jobs, so it can fill up a hobby
database on Heroku in less than a day.
