### PR TITLE
repair migrations

### DIFF
--- a/db/migrate/20130522014405_add_api_key_to_user.rb
+++ b/db/migrate/20130522014405_add_api_key_to_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddApiKeyToUser < ActiveRecord::Migration[4.2]
+class AddAPIKeyToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :api_key, :string
   end

--- a/db/migrate/20230223045525_add_null_false_to_associations.rb
+++ b/db/migrate/20230223045525_add_null_false_to_associations.rb
@@ -2,8 +2,10 @@
 
 class AddNullFalseToAssociations < ActiveRecord::Migration[7.0]
   def change
-    Feed.where(user: nil).update_all(user_id: User.first.id)
-    Group.where(user: nil).update_all(user_id: User.first.id)
+    if User.any?
+      Feed.where(user: nil).update_all(user_id: User.first.id)
+      Group.where(user: nil).update_all(user_id: User.first.id)
+    end
 
     change_column_null :feeds, :user_id, false
     change_column_null :groups, :user_id, false

--- a/db/migrate/20230223231930_add_username_to_users.rb
+++ b/db/migrate/20230223231930_add_username_to_users.rb
@@ -4,7 +4,7 @@ class AddUsernameToUsers < ActiveRecord::Migration[7.0]
   def change
     add_column :users, :username, :string
     add_index :users, :username, unique: true
-    User.first.update!(username: "stringer")
+    User.first.update!(username: "stringer") if User.any?
     change_column_null :users, :username, false
   end
 end

--- a/db/migrate/20230313034938_add_admin_to_users.rb
+++ b/db/migrate/20230313034938_add_admin_to_users.rb
@@ -4,7 +4,7 @@ class AddAdminToUsers < ActiveRecord::Migration[7.0]
   def change
     add_column :users, :admin, :boolean
 
-    User.first.update!(admin: true)
+    User.first.update!(admin: true) if User.any?
 
     change_column_null :users, :admin, false
   end


### PR DESCRIPTION
**What**

This makes a couple of updates to the migrations based on [this
conversation][is]:

* Rename `Api` -> `API`. This is expected by Rails inflections.
* Add conditional checks to migrations that look for a user. If a person
  hasn't set up an account yet, the migrations should still run
  gracefully.

[is]: https://github.com/stringer-rss/stringer/issues/1046
