### PR TITLE
adjust supercronic download to allow multiarch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,18 @@ RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales \
 
 ENV LC_ALL C.UTF-8
 
-ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.3/supercronic-linux-amd64 \
-    SUPERCRONIC=supercronic-linux-amd64 \
-    SUPERCRONIC_SHA1SUM=96960ba3207756bb01e6892c978264e5362e117e
+ARG ARCH=amd64
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.3/supercronic-linux-$ARCH \
+    SUPERCRONIC=supercronic-linux-$ARCH \
+    SUPERCRONIC_amd64_SHA1SUM=96960ba3207756bb01e6892c978264e5362e117e \
+    SUPERCRONIC_arm_SHA1SUM=8c1e7af256ee35a9fcaf19c6a22aa59a8ccc03ef \
+    SUPERCRONIC_arm64_SHA1SUM=f0e8049f3aa8e24ec43e76955a81b76e90c02270 \
+    SUPERCRONIC_SHA1SUM="SUPERCRONIC_${ARCH}_SHA1SUM"
 
+# required to make the ${!...} expansion work
+SHELL ["/bin/bash", "-c"]
 RUN curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && echo "${!SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
  && chmod +x "$SUPERCRONIC" \
  && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
  && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic


### PR DESCRIPTION
The download of `supercronic` in the Dockerfile hardcodes `amd64` as the architecture, but we can make it flexible to allow for multiarch builds.

For this purpose I added all three of the SHA1SUMs and just select the "correct" one to use based on the `ARCH` build argument (which has a default of `amd64`).

This built successfully for me with the command:
```
docker build -t stringer-arch-test --build-arg ARCH=arm64 .
```
(as well as `arm` and `amd64`)

I changed the shell that executes the Dockerfile to bash to take advantage of the `${!ENV_VAR_CONTAINING_OTHER_ENV_VAR_NAME}` construction - the `SUPERCRONIC_SHA1SUM` arg contains one of `SUPERCRONIC_{amd64,arm,arm64}_SHA1SUM`, and we need to evaluate this value as an env var. The easiest way to do this with `/bin/sh` seems to be `eval echo \$$SUPERCRONIC_SHA1SUM`, but that's a bit unsafe since we're using `eval` so I selected to switch to bash instead.