### PR TITLE
fix N+1 queries on feeds/index

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,7 @@ Rails/BulkChangeTable: { Enabled: false }
 Rails/RedundantPresenceValidationOnBelongsTo: { Enabled: false }
 RSpec/AlignLeftLetBrace: { Enabled: false }
 RSpec/AlignRightLetBrace: { Enabled: false }
+Rails/HasManyOrHasOneDependent: { Enabled: false }
 RSpec/IndexedLet: { Enabled: false }
 RSpec/StubbedMock: { Enabled: false }
 Rails/SchemaComment: { Enabled: false }

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -2,7 +2,7 @@
 
 class FeedsController < ApplicationController
   def index
-    @feeds = authorization.scope(FeedRepository.list)
+    @feeds = authorization.scope(FeedRepository.list.with_unread_stories_counts)
   end
 
   def show

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -8,6 +8,8 @@ class Story < ApplicationRecord
 
   delegate :group_id, :user_id, to: :feed
 
+  scope :unread, -> { where(is_read: false) }
+
   UNTITLED = "[untitled]"
 
   def headline

--- a/app/views/feeds/_feed.html.erb
+++ b/app/views/feeds/_feed.html.erb
@@ -1,11 +1,11 @@
 <li class="feed" id="feed-<%= feed.id%>" data-id="<%= feed.id %>">
   <div class="feed-line">
     <div class="feed-title-container">
-      <p class="feed-title <%= feed.unread_stories.any? ? "feed-unread" : "" %>">
+      <p class="feed-title <%= feed.unread_stories_count > 0 ? "feed-unread" : "" %>">
         <i class="icon-circle status <%= feed.status_bubble %>" data-toggle="tooltip" title="<%= t("partials.feed.status_bubble.#{feed.status_bubble}") if feed.status_bubble %>" data-placement="left"></i>
         <a href="/feed/<%= feed.id %>">
-          <% if feed.unread_stories.any? %>
-            (<%= feed.unread_stories.count %>)
+          <% if feed.unread_stories_count > 0 %>
+            (<%= feed.unread_stories_count %>)
           <% end %>
           <%= feed.name %>
         </a>

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -1,29 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe "Feed" do
-  describe "#status_bubble" do
-    it "returns 'yellow' when status == 'red' and there are stories" do
-      feed = Feed.new(status: :red, stories: [Story.new])
+  describe ".with_unread_stories_counts" do
+    it "returns feeds with unread stories counts" do
+      create(:story, :unread)
 
-      expect(feed.status_bubble).to eq("yellow")
+      feed = Feed.with_unread_stories_counts.first
+
+      expect(feed.unread_stories_count).to eq(1)
     end
 
-    it "returns 'red' if status is 'red' and there are no stories" do
-      feed = Feed.new(status: :red)
+    it "includes feeds with no unread stories" do
+      create(:story)
 
-      expect(feed.status_bubble).to eq("red")
-    end
+      feed = Feed.with_unread_stories_counts.first
 
-    it "returns nil when no status is set" do
-      feed = Feed.new
-
-      expect(feed.status_bubble).to be_nil
-    end
-
-    it "returns :green when status is :green" do
-      feed = Feed.new(status: :green)
-
-      expect(feed.status_bubble).to eq("green")
+      expect(feed.unread_stories_count).to eq(0)
     end
   end
 
@@ -47,6 +39,32 @@ RSpec.describe "Feed" do
       create(:story, feed:)
 
       expect(feed.unread_stories).to be_empty
+    end
+  end
+
+  describe "#status_bubble" do
+    it "returns 'yellow' when status == 'red' and there are stories" do
+      feed = Feed.new(status: :red, stories: [Story.new])
+
+      expect(feed.status_bubble).to eq("yellow")
+    end
+
+    it "returns 'red' if status is 'red' and there are no stories" do
+      feed = Feed.new(status: :red)
+
+      expect(feed.status_bubble).to eq("red")
+    end
+
+    it "returns nil when no status is set" do
+      feed = Feed.new
+
+      expect(feed.status_bubble).to be_nil
+    end
+
+    it "returns :green when status is :green" do
+      feed = Feed.new(status: :green)
+
+      expect(feed.status_bubble).to eq("green")
     end
   end
 

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -3,6 +3,20 @@
 RSpec.describe "Story" do
   let(:story) { build_stubbed(:story) }
 
+  describe ".unread" do
+    it "returns stories where is_read is false" do
+      story = create(:story, :unread)
+
+      expect(Story.unread).to eq([story])
+    end
+
+    it "does not return stories where is_read is true" do
+      create(:story, :read)
+
+      expect(Story.unread).to be_empty
+    end
+  end
+
   describe "#headline" do
     it "truncates to 50 chars" do
       story = Story.new(title: "a" * 100)


### PR DESCRIPTION
This adds a new relation for `Feed#unread_stories` and a new scope to
easily pull in the unread stories count, and uses them on `feeds/index`
to avoid N+1 queries checking for the presence and count of unread
stories.

In my testing, this significantly improves performance on the page.
There is still a smaller N+1 when checking the status for red feeds, and
rendering partials for each feed adds up quite a bit, too, so we may
benefit from in-lining the partial.
