### PR TITLE
update circleci to build image and push to dockerhub, pending approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,18 +109,17 @@ jobs:
           command: |
             COVERAGE=false bundle exec rspec spec/system/
 
-
 workflows:
   test-build-and-publish-image:
     jobs:
       - run-tests
-      - wait-for-approval:
-          type: approval
       - docker/publish:
-          cache_from: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:latest
-          image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
-          tag: latest
+          cache_from: stringerrss/stringer:latest
+          image: stringerrss/stringer
+          tag: latest,$CIRCLE_SHA1
           update-description: false
           requires:
-            - wait-for-approval
             - run-tests
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,10 @@ version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.2.3
   node: circleci/node@5.0.0
+  docker: circleci/docker@2.2.0
 
 jobs:
-  build:
+  run-tests:
     parallelism: 1
     docker:
       - image: cimg/ruby:3.2.2-browsers
@@ -107,3 +108,19 @@ jobs:
           name: Run system tests
           command: |
             COVERAGE=false bundle exec rspec spec/system/
+
+
+workflows:
+  test-build-and-publish-image:
+    jobs:
+      - run-tests
+      - wait-for-approval:
+          type: approval
+      - docker/publish:
+          cache_from: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:latest
+          image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+          tag: latest
+          update-description: false
+          requires:
+            - wait-for-approval
+            - run-tests


### PR DESCRIPTION
Confidence that this will work: 0% :)

I renamed the previous `build` job to `run_tests`, since it seemed more apt, if we're adding a "build the docker image" step. I think this requires a change on the github repo / PR config, though, so I'm fine reverting that change.

This PR hopefully adds the `build-and-publish-image` workflow, which waits for tests to run + waits for an approval from a maintainer / someone with merge access to the repo to run it. I think we need to create the `stringer-rss` Dockerhub user/organization, and we must use `DOCKER_LOGIN` and `DOCKER_PASSWORD` env vars but I'm not sure where to place them in the CI file in a safe way. (is this something we set up in CircleCI itself as a secret?)