### PR TITLE
Docker: remove docker install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
     steps:
       - checkout
       - browser-tools/install-browser-tools
-      - docker/install-docker-tools
 
       # - node/install:
       #     node-version: 16.13.1


### PR DESCRIPTION
This was only installing in the test container, not the Docker publish
container, which appears to already have it.
