### PR TITLE
Fix typo in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - 80:8080
     environment:
       - SECRET_KEY_BASE=<your configuration>
-      - ENCRYPTION_PRIMARY_KEY<your configuration>
+      - ENCRYPTION_PRIMARY_KEY=<your configuration>
       - ENCRYPTION_DETERMINISTIC_KEY=<your configuration>
       - ENCRYPTION_KEY_DERIVATION_SALT=<your configuration>
       - PORT=8080


### PR DESCRIPTION
Missing equal sign (=) in variable 'environment': ENCRYPTION_PRIMARY_KEY