### PR TITLE
Build Docker image and push to Dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,9 @@ version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.2.3
   node: circleci/node@5.0.0
-  docker: circleci/docker@2.2.0
 
 jobs:
-  run-tests:
+  build:
     parallelism: 1
     docker:
       - image: cimg/ruby:3.2.2-browsers
@@ -108,18 +107,3 @@ jobs:
           name: Run system tests
           command: |
             COVERAGE=false bundle exec rspec spec/system/
-
-workflows:
-  test-build-and-publish-image:
-    jobs:
-      - run-tests
-      - docker/publish:
-          cache_from: stringerrss/stringer:latest
-          image: stringerrss/stringer
-          tag: latest,$CIRCLE_SHA1
-          update-description: false
-          requires:
-            - run-tests
-          filters:
-            branches:
-              only: main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Build Docker image and push to Dockerhub
+
+on:
+  push
+env:
+  IMAGE_NAME: stringerrss/stringer
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Extract Docker sha tag
+        id: get-tag-sha
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: type=sha
+
+      - name: Extract Docker latest tag
+        id: get-tag-latest
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: type=raw, value=latest
+
+      - name: Log in to Docker Hub
+        if: ${{ github.ref_name == 'main' }}
+        id: login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push
+        id: build-and-push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.ref_name == 'main' }}
+          tags: |
+            ${{ steps.get-tag-latest.outputs.tags }}
+            ${{ steps.get-tag-sha.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha


### PR DESCRIPTION
As mentioned in [#1051](https://github.com/stringer-rss/stringer/issues/1051#issuecomment-1679387966), the CircleCI docker build step isn't working, and we want to move it to a Github Action instead. This PR has two commits:

- first, revert the CircleCI additions so that the CircleCI tests file is clean (via reverting the two commits from #1065)
- second, add a build+push to dockerhub github action.

This will require two secrets that I *believe* can be set in the repository settings somewhere: one for a `DOCKERHUB_USERNAME` and another for a `DOCKERHUB_TOKEN`. I also went ahead and added both an amd64 and an arm64 build here, and am hoping that it just works (tm).

I also once again set the build and push to only happen when `main` is pushed to / gets new commits, but I think we can change that to work only on this branch from my fork if we want to test before merging.