### PR TITLE
Set Latest version of stringer Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - POSTGRES_DB=stringer
 
   web:
-    image: mockdeep/stringer
+    image: mockdeep/stringer:latest
     build: .
     depends_on:
       - postgres

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -43,7 +43,7 @@ docker run --detach \
     -e FETCH_FEEDS_CRON="*/5 * * * *" \ # optional
     -e CLEANUP_CRON="0 0 * * *" \ # optional
     -p 127.0.0.1:8080:8080 \
-    stringer-rss/stringer
+    mockdeep/stringer:latest
 ```
 
 That's it! You now have a fully working Stringer instance up and running!


### PR DESCRIPTION
Hey ! 

As mentionned [here](https://github.com/stringer-rss/stringer/pull/1071/files), I splitted my first PR into small one. As we can merge it easily !

In this one : 
- Sync Stringer Docker Image between documentation and docker-compose

Feel free to comment if I missed something