### PR TITLE
precompile assets in the dockerfile before launching. closes #1086

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -7,6 +7,8 @@ if [ -z "$DATABASE_URL" ]; then
   exit 1
 fi
 
+rails assets:precompile
+
 : ${FETCH_FEEDS_CRON:='*/5 * * * *'}
 : ${CLEANUP_CRON:='0 0 * * *'}
 


### PR DESCRIPTION
I added an asset precompilation step to the Dockerfile. However, this didn't work out of the box - it seems like [rails needs secret keys/environment variables to be loaded](https://github.com/rails/rails/issues/32947) to run any command, even just an asset precompilation. So I added some dummy arguments to the Dockerfile that are only available during build, not during runtime. Unfortunately, this seems to be the standard: e.g. [Mastodon](https://github.com/mastodon/mastodon/blob/main/Dockerfile#L100) does this.

This wasn't quite satisfactory, so I went with another option: to precompile assets in `docker/start.sh`, i.e. the entrypoint of the container. This is also a little inconvenient, because if someone changes the entrypoint to the container, then they might not precompile the assets and their image might be broken. But this seemed a lot cleaner than the following:

```Dockerfile
...
ADD . /app
# required for assets precompilation
ARG SECRET_KEY_BASE='dummy'
ARG ENCRYPTION_PRIMARY_KEY='dummy'
ARG ENCRYPTION_DETERMINISTIC_KEY='dummy'
ARG ENCRYPTION_KEY_DERIVATION_SALT='dummy'
RUN rails assets:precompile
```

I also tried fetching env vars with defaults in the `config/application.rb`, but the `config/initializers/dotenv.rb` prevented me from starting the container without the env vars actually set. (side note, I think we can deprecate `SECRET_KEY_BASE` now?)