### PR TITLE
Add Nano and Vim into Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN gem install bundler:$BUNDLER_VERSION && bundle install
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-      supervisor locales nodejs \
+      supervisor locales nodejs vim nano \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Hey ! 

I found this [issue](https://github.com/stringer-rss/stringer/issues/1087) and I had time to answer it. So here is the PR. 

Today, this update install : 
- Nano v7.2
- Vim v9.0

Feel free to comment if I missed something