### PR TITLE
don't ignore existing tmp folder. closes #1096

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 .git/*
 .gitignore
 log/*
-tmp/*


### PR DESCRIPTION
The Docker image was building without copying the contents of `./tmp`, so the `/app/tmp/pids/.keep` folder didn't exist within the Docker container anymore. By removing this line from the `.dockerignore`, we create that folder and the image is back to working successfully.

I tested this on my local and the new image builds fine and loads stringer in the browser, (although we still have a missing assets issue).