### PR TITLE
set RAILS_SERVE_STATIC_FILES in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,6 @@ RUN useradd -m stringer
 RUN chown -R stringer:stringer /app
 USER stringer
 
+ENV RAILS_SERVE_STATIC_FILES=true
+
 CMD /app/start.sh


### PR DESCRIPTION
Without setting this variable, Rails won't serve static files from within the Docker container while in production mode. We could circumvent this by having a shared volume to the assets folder and serving the assets through a reverse proxy, but it seems more trouble than it's worth at this point.