### PR TITLE
Removed memoization from feed/create and feed/export_to_opml specs

### DIFF
--- a/spec/commands/feed/create_spec.rb
+++ b/spec/commands/feed/create_spec.rb
@@ -11,11 +11,9 @@ RSpec.describe Feed::Create do
   end
 
   context "feed can be discovered" do
-    let(:feed_url) { "http://feed.com/atom.xml" }
-    let(:feed_result) { double(title: feed.name, feed_url: feed.url) }
-    let(:feed) { build(:feed) }
-
     it "parses and creates the feed if discovered" do
+      feed = build(:feed)
+      feed_result = double(title: feed.name, feed_url: feed.url)
       expect(FeedDiscovery).to receive(:call).and_return(feed_result)
 
       expect { described_class.call("http://feed.com", user: default_user) }
@@ -23,15 +21,11 @@ RSpec.describe Feed::Create do
     end
 
     context "title includes a script tag" do
-      let(:feed_result) do
-        double(
-          title: "foo<script>alert('xss');</script>bar",
-          feed_url: feed.url
-        )
-      end
-
       it "deletes the script tag from the title" do
-        expect(FeedDiscovery).to receive(:call).and_return(feed_result)
+        feed =
+          double(title: "foo<script>alert('xss');</script>bar", feed_url: nil)
+
+        expect(FeedDiscovery).to receive(:call).and_return(feed)
 
         feed = described_class.call("http://feed.com", user: default_user)
 

--- a/spec/commands/feed/export_to_opml_spec.rb
+++ b/spec/commands/feed/export_to_opml_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Feed::ExportToOpml do
-  let(:feed_one) { build(:feed)      }
-  let(:feed_two) { build(:feed)      }
-  let(:feeds) { [feed_one, feed_two] }
-
   it "returns OPML XML" do
-    result = described_class.call(feeds)
+    feed_one, feed_two = build_pair(:feed)
+    result = described_class.call([feed_one, feed_two])
 
     outlines = Nokogiri.XML(result).xpath("//body//outline")
     expect(outlines.size).to eq(2)
@@ -24,7 +21,8 @@ RSpec.describe Feed::ExportToOpml do
   end
 
   it "has a proper title" do
-    result = described_class.call(feeds)
+    feed_one, feed_two = build_pair(:feed)
+    result = described_class.call([feed_one, feed_two])
 
     title = Nokogiri.XML(result).xpath("//head//title").first
     expect(title.content).to eq("Feeds from Stringer")


### PR DESCRIPTION
Updated spec files below to address "MultipleMemoizedHelpers" cop

- spec/feeds/create_spec.rb
- spec/feeds/export_to_opml_spec.rb