### PR TITLE
A11y: add accessibility overrides for system tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
 end
 
 group :test do
+  gem "axe-core-rspec"
   gem "selenium-webdriver"
   gem "webdrivers"
   gem "with_model"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,17 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    axe-core-api (4.8.0)
+      dumb_delegator
+      virtus
+    axe-core-rspec (4.8.0)
+      axe-core-api
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.4)
@@ -96,6 +107,8 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     coveralls_reborn (0.28.0)
@@ -110,6 +123,8 @@ GEM
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dotenv (2.8.1)
@@ -118,6 +133,7 @@ GEM
       railties (>= 3.2)
     drb (2.2.0)
       ruby2_keywords
+    dumb_delegator (1.0.0)
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -148,6 +164,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     io-console (0.6.0)
     irb (1.9.0)
       rdoc
@@ -334,6 +351,7 @@ GEM
       tins (~> 1.0)
     thor (1.3.0)
     thread (0.2.2)
+    thread_safe (0.3.6)
     timeout (0.4.1)
     tins (1.32.1)
       sync
@@ -342,6 +360,10 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -371,6 +393,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  axe-core-rspec
   bcrypt
   bootsnap
   capybara

--- a/spec/support/axe_core.rb
+++ b/spec/support/axe_core.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "axe-rspec"
+
+module AccessibilityOverrides
+  A11Y_SKIP = [
+    "aria-required-children",
+    "color-contrast",
+    "html-has-lang",
+    "label-title-only",
+    "landmark-one-main",
+    "link-name",
+    "page-has-heading-one",
+    "region"
+  ].freeze
+
+  def visit(*, accessible: true, a11y_skip: A11Y_SKIP)
+    page.visit(*)
+
+    yield if block_given?
+
+    check_accessibility(a11y_skip:) if accessible
+  end
+
+  def click_on(*, a11y_skip: A11Y_SKIP, **)
+    page.click_on(*, **)
+
+    yield if block_given?
+
+    check_accessibility(a11y_skip:)
+  end
+
+  def check_accessibility(a11y_skip:)
+    within_window(current_window) do
+      expect(page).to have_css("div")
+      expect(page).to be_axe_clean.skipping(*a11y_skip)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include(AccessibilityOverrides, type: :system)
+end


### PR DESCRIPTION
**What**

This adds the `axe-core-rspec` gem and overrides the Capybara methods
`visit` and `click_on` to run accessibility checks after each click or
visit.

**Notes**

This doesn't currently have any affordances to reduce test flake. `axe`
is likely to end up running on partially loaded pages which could lead
to unexpected test failures. I'm planning on running the build on repeat
and fixing the errors as they come up.

I might also add some sort of "expect_text" parameter to require *all*
calls to expect some sort of text on the resulting page. I'm hesitant to
vary too far from the Capbyara API, though.
