### PR TITLE
update Downloads helpers to use synchronize

### DIFF
--- a/spec/support/downloads.rb
+++ b/spec/support/downloads.rb
@@ -1,32 +1,23 @@
 # frozen_string_literal: true
 
 module Downloads
-  TIMEOUT = Capybara.default_max_wait_time
-  PATH    = Rails.root.join("tmp/downloads")
+  PATH = Rails.root.join("tmp/downloads")
 
   class << self
     def clear
       FileUtils.rm_f(downloads)
     end
 
-    def content_for(filename)
-      wait_for_download(filename)
-
-      File.read(PATH.join(filename))
+    def content_for(page, filename)
+      page.document.synchronize(errors: [Errno::ENOENT]) do
+        File.read(PATH.join(filename))
+      end
     end
 
     private
 
     def downloads
       Dir[PATH.join("*")]
-    end
-
-    def wait_for_download(filename)
-      Timeout.timeout(TIMEOUT) { sleep(0.1) until downloaded?(filename) }
-    end
-
-    def downloaded?(filename)
-      File.exist?(PATH.join(filename))
     end
   end
 end

--- a/spec/system/export_spec.rb
+++ b/spec/system/export_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "exporting feeds" do
 
     click_on "Export"
 
-    xml = Capybara.string(Downloads.content_for("stringer.opml"))
+    xml = Capybara.string(Downloads.content_for(page, "stringer.opml"))
     expect(xml).to have_css("outline[title='#{feed.name}']")
   end
 end


### PR DESCRIPTION
Use Capybara's built-in `synchronize` method rather than handling the
timeout ourselves.
