### PR TITLE
refactor: Removed Memoization From Commands Specs

### DIFF
--- a/spec/commands/feed/import_from_opml_spec.rb
+++ b/spec/commands/feed/import_from_opml_spec.rb
@@ -1,104 +1,107 @@
 # frozen_string_literal: true
 
 RSpec.describe Feed::ImportFromOpml do
-  let(:subscriptions) do
+  tmw_football = {
+    name: "TMW Football Transfer News",
+    url: "http://www.transfermarketweb.com/rss"
+  }
+
+  giant_robots = {
+    name: "GIANT ROBOTS SMASHING INTO OTHER GIANT ROBOTS - Home",
+    url: "http://feeds.feedburner.com/GiantRobotsSmashingIntoOtherGiantRobots"
+  }
+
+  autoblog = { name: "Autoblog", url: "http://feeds.autoblog.com/weblogsinc/autoblog/" }
+  city_guide = { name: "City Guide News", url: "http://www.probki.net/news/RSS_news_feed.asp" }
+
+  def read_subscriptions
     File.open(
-      File.expand_path(
-        "../../support/files/subscriptions.xml",
-        __dir__
-      )
+      File.expand_path("../../support/files/subscriptions.xml", __dir__)
     )
   end
-  let(:group1) { Group.find_by!(name: "Football News") }
-  let(:group2) { Group.find_by!(name: "RoR")           }
+
+  def create_feed(feed_details)
+    create(:feed, feed_details)
+  end
+
+  def find_feed(feed_details)
+    Feed.where(feed_details)
+  end
 
   context "adding group_id for existing feeds" do
-    let!(:feed1) do
-      create(:feed, name: "TMW Football Transfer News", url: "http://www.transfermarketweb.com/rss")
-    end
-    let!(:feed2) do
-      create(
-        :feed,
-        name: "GIANT ROBOTS SMASHING INTO OTHER GIANT ROBOTS - Home",
-        url: "http://feeds.feedburner.com/GiantRobotsSmashingIntoOtherGiantRobots"
-      )
-    end
-
     it "retains exising feeds" do
-      described_class.call(subscriptions, user: default_user)
+      feed1 = create_feed(tmw_football)
+      feed2 = create_feed(giant_robots)
+
+      described_class.call(read_subscriptions, user: default_user)
 
       expect(feed1).to be_valid
       expect(feed2).to be_valid
     end
 
     it "creates new groups" do
-      described_class.call(subscriptions, user: default_user)
+      described_class.call(read_subscriptions, user: default_user)
 
-      expect(group1).to be
-      expect(group2).to be
+      expect(Group.find_by(name: "Football News")).to be
+      expect(Group.find_by(name: "RoR")).to be
     end
 
     it "sets group for existing feeds" do
-      expect { described_class.call(subscriptions, user: default_user) }
+      feed1 = create_feed(tmw_football)
+      feed2 = create_feed(giant_robots)
+
+      expect { described_class.call(read_subscriptions, user: default_user) }
         .to change_record(feed1, :group_name).from(nil).to("Football News")
         .and change_record(feed2, :group_name).from(nil).to("RoR")
     end
   end
 
   context "creates new feeds with groups" do
-    let(:feed1) do
-      Feed.where(name: "TMW Football Transfer News", url: "http://www.transfermarketweb.com/rss")
-    end
-    let(:feed2) do
-      Feed.where(
-        name: "GIANT ROBOTS SMASHING INTO OTHER GIANT ROBOTS - Home",
-        url: "http://feeds.feedburner.com/GiantRobotsSmashingIntoOtherGiantRobots"
-      )
-    end
-
     it "creates groups" do
-      described_class.call(subscriptions, user: default_user)
+      described_class.call(read_subscriptions, user: default_user)
 
-      expect(group1).to be
-      expect(group1).to be
+      expect(Group.find_by(name: "Football News")).to be
+      expect(Group.find_by(name: "RoR")).to be
     end
 
     it "creates feeds" do
-      described_class.call(subscriptions, user: default_user)
+      described_class.call(read_subscriptions, user: default_user)
 
-      expect(feed1).to exist
-      expect(feed2).to exist
+      expect(find_feed(tmw_football)).to exist
+      expect(find_feed(giant_robots)).to exist
     end
 
     it "sets group" do
-      described_class.call(subscriptions, user: default_user)
+      described_class.call(read_subscriptions, user: default_user)
 
-      expect(feed1.first.group).to eq(group1)
-      expect(feed2.first.group).to eq(group2)
+      expect(find_feed(tmw_football).first.group)
+        .to eq(Group.find_by(name: "Football News"))
+      expect(find_feed(giant_robots).first.group)
+        .to eq(Group.find_by(name: "RoR"))
     end
 
     it "does not create empty group" do
-      described_class.call(subscriptions, user: default_user)
+      described_class.call(read_subscriptions, user: default_user)
 
       expect(Group.find_by(name: "Empty Group")).to be_nil
     end
   end
 
   context "creates new feeds without group" do
-    let(:feed1) { Feed.where(name: "Autoblog", url: "http://feeds.autoblog.com/weblogsinc/autoblog/").first }
-    let(:feed2) { Feed.where(name: "City Guide News", url: "http://www.probki.net/news/RSS_news_feed.asp").first }
-
     it "does not create any new group for feeds without group" do
-      described_class.call(subscriptions, user: default_user)
+      described_class.call(read_subscriptions, user: default_user)
+
+      group1 = Group.find_by(name: "Football News")
+      group2 = Group.find_by(name: "RoR")
 
       expect(Group.where.not(id: [group1.id, group2.id]).count).to eq(0)
     end
 
     it "creates feeds without group_id" do
-      described_class.call(subscriptions, user: default_user)
+      described_class.call(read_subscriptions, user: default_user)
 
-      expect(feed1.group_id).to be_nil
-      expect(feed2.group_id).to be_nil
+      expect(find_feed(autoblog).first.group_id).to be_nil
+      expect(find_feed(city_guide).first.group_id).to be_nil
     end
   end
 end

--- a/spec/commands/fever_api/read_favicons_spec.rb
+++ b/spec/commands/fever_api/read_favicons_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe FeverAPI::ReadFavicons do
-  subject { described_class }
-
   it "returns a fixed icon list if requested" do
-    expect(subject.call({ favicons: nil })).to eq(
+    expect(described_class.call({ favicons: nil })).to eq(
       favicons: [
         {
           id: 0,
@@ -15,6 +13,6 @@ RSpec.describe FeverAPI::ReadFavicons do
   end
 
   it "returns an empty hash otherwise" do
-    expect(subject.call({})).to eq({})
+    expect(described_class.call({})).to eq({})
   end
 end

--- a/spec/commands/fever_api/write_mark_feed_spec.rb
+++ b/spec/commands/fever_api/write_mark_feed_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe FeverAPI::WriteMarkFeed do
-  let(:feed_marker) { double("feed marker") }
-  let(:marker_class) { double("marker class") }
-
   def params(feed, before:)
     authorization = Authorization.new(feed.user)
 

--- a/spec/commands/story/mark_as_read_spec.rb
+++ b/spec/commands/story/mark_as_read_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe MarkAsRead do
-  let(:story) { create(:story, is_read: false) }
-
   it "marks a story as read" do
+    story = create(:story, is_read: false)
+
     expect { described_class.call(story.id) }
       .to change_record(story, :is_read).from(false).to(true)
   end


### PR DESCRIPTION
Completed removal of remaining memoization across specs in commands folder.

Modified specs:
	-  spec/commands/feed/import_from_opml_spec.rb
	-  spec/commands/fever_api/read_favicons_spec.rb
	-  spec/commands/fever_api/write_mark_feed_spec.rb
	-  spec/commands/story/mark_as_read_spec.rb