### PR TITLE
refactor: removed memoization from repository spec

### DIFF
--- a/spec/repositories/feed_repository_spec.rb
+++ b/spec/repositories/feed_repository_spec.rb
@@ -2,15 +2,8 @@
 
 RSpec.describe FeedRepository do
   describe ".fetch" do
-    let(:feed) { Feed.new(id: 1) }
-
-    it "finds by id" do
-      expect(Feed).to receive(:find).with(feed.id).and_return(feed)
-      described_class.fetch(feed.id)
-    end
-
-    it "returns found feed" do
-      allow(Feed).to receive(:find).with(feed.id).and_return(feed)
+    it "finds and returns found feed" do
+      feed = create(:feed)
 
       result = described_class.fetch(feed.id)
 
@@ -45,9 +38,8 @@ RSpec.describe FeedRepository do
   end
 
   describe ".update_last_fetched" do
-    let(:timestamp) { Time.zone.now.round }
-
     it "saves the last_fetched timestamp" do
+      timestamp = Time.zone.now.round
       feed = build(:feed)
 
       described_class.update_last_fetched(feed, timestamp)
@@ -56,6 +48,7 @@ RSpec.describe FeedRepository do
     end
 
     it "rejects weird timestamps" do
+      timestamp = Time.zone.now.round
       weird_timestamp = Time.parse("Mon, 01 Jan 0001 00:00:00 +0100")
       feed = Feed.new(last_fetched: timestamp)
 
@@ -65,6 +58,7 @@ RSpec.describe FeedRepository do
     end
 
     it "doesn't update if timestamp is nil" do
+      timestamp = Time.zone.now.round
       feed = Feed.new(last_fetched: timestamp)
 
       described_class.update_last_fetched(feed, nil)
@@ -73,6 +67,7 @@ RSpec.describe FeedRepository do
     end
 
     it "doesn't update if timestamp is older than the current value" do
+      timestamp = Time.zone.now.round
       feed = Feed.new(last_fetched: timestamp)
       one_week_ago = timestamp - 1.week
 

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -2,16 +2,17 @@
 
 RSpec.describe StoryRepository do
   describe ".add" do
-    let(:feed) { double(url: "http://blog.golang.org/feed.atom") }
-
-    before { allow(Story).to receive(:create) }
+    def create_feed(url: "http://blog.golang.org/feed.atom")
+      double(url:)
+    end
 
     it "normalizes story urls" do
-      entry = double(
-        url: "//blog.golang.org/context",
-        title: "",
-        content: ""
-      ).as_null_object
+      feed = create_feed
+      entry = double(url: "//blog.golang.org/context", title: "", content: "")
+              .as_null_object
+
+      allow(Story).to receive(:create)
+
       expect(described_class)
         .to receive(:normalize_url).with(entry.url, feed.url)
 
@@ -19,6 +20,7 @@ RSpec.describe StoryRepository do
     end
 
     it "deletes line and paragraph separator characters from titles" do
+      feed = create_feed
       entry = double(title: "n\u2028\u2029", content: "").as_null_object
       allow(described_class).to receive(:normalize_url)
 
@@ -28,6 +30,7 @@ RSpec.describe StoryRepository do
     end
 
     it "deletes script tags from titles" do
+      feed = create_feed
       entry = double(title: "n<script>alert('xss');</script>", content: "")
               .as_null_object
       allow(described_class).to receive(:normalize_url)
@@ -38,6 +41,7 @@ RSpec.describe StoryRepository do
     end
 
     it "sets the enclosure url when present" do
+      feed = create_feed
       entry = instance_double(
         Feedjira::Parser::ITunesRSSItem,
         enclosure_url: "http://example.com/audio.mp3",
@@ -53,6 +57,7 @@ RSpec.describe StoryRepository do
     end
 
     it "does not set the enclosure url when not present" do
+      feed = create_feed
       entry = instance_double(
         Feedjira::Parser::RSSEntry,
         title: "",


### PR DESCRIPTION
Removed "let" and "before" from FeedRepository spec and StoryRepository spec

Files modified:
	spec/repositories/feed_repository_spec.rb
	spec/repositories/story_repository_spec.rb