### PR TITLE
Docker: run Docker buildx on PR and manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,15 @@
 name: Build Docker image and push to Dockerhub
 
 on:
-  push
+  push:
+  pull_request:
+  workflow_dispatch:
+
 env:
   IMAGE_NAME: stringerrss/stringer
 
 jobs:
-  buildx:
+  build_docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This updates our Docker build configuration to also run on pull request,
as well as allowing for on-demand builds with the `workflow_dispatch`
option.
