### PR TITLE
CircleCI: clean up bundled gems before caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,10 @@ jobs:
 
       - run: # Install Ruby dependencies
           name: Bundle Install
-          command: bundle check || bundle install
-
-      # - run:
-      #     name: Bundler Audit
-      #     command: bundle exec bundle audit
+          command: |
+            bundle config set --local frozen 'true'
+            bundle install
+            bundle clean
 
       - save_cache:
           key: bundle-v1-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
This should reduce the cache size for bundled gems.