### PR TITLE
Update ReadItems to order stories by published and id

### DIFF
--- a/app/commands/fever_api/read_items.rb
+++ b/app/commands/fever_api/read_items.rb
@@ -22,7 +22,7 @@ module FeverAPI::ReadItems
         else
           unread_stories(since_id, authorization)
         end
-      items.map(&:as_fever_json)
+      items.order(:published, :id).map(&:as_fever_json)
     end
 
     def total_items(item_ids, authorization)

--- a/spec/commands/fever_api/read_items_spec.rb
+++ b/spec/commands/fever_api/read_items_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe FeverAPI::ReadItems do
     authorization = Authorization.new(default_user)
 
     expect(described_class.call(authorization:, items: nil, with_ids:)).to eq(
-      items: other_stories.map(&:as_fever_json),
+      items: other_stories.reverse.map(&:as_fever_json),
       total_items: 2
     )
   end


### PR DESCRIPTION
This will make it so that they are returned in a stable order.