### PR TITLE
FIX: Add default precision to db

### DIFF
--- a/db/migrate/20240226201050_add_precision_to_timestamps.rb
+++ b/db/migrate/20240226201050_add_precision_to_timestamps.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class AddPrecisionToTimestamps < ActiveRecord::Migration[7.1]
+  SKIP_TABLES = [:schema_migrations, :ar_internal_metadata].freeze
+
+  def up
+    migrate_precision(precision: 6)
+  end
+
+  def down
+    migrate_precision(precision: nil)
+  end
+
+  def migrate_precision(precision:)
+    table_names = ActiveRecord::Base.connection.tables.map(&:to_sym)
+    table_names.each do |table|
+      next if SKIP_TABLES.include?(table)
+
+      ActiveRecord::Base.connection.columns(table).each do |column|
+        next unless datetime_column?(column)
+
+        change_column(table, column.name, :datetime, precision:)
+      end
+    end
+  end
+
+  private
+
+  def datetime_column?(column)
+    column.sql_type_metadata.type == :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_08_01_025234) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_26_201050) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -18,9 +18,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_08_01_025234) do
   create_table "feeds", id: :serial, force: :cascade do |t|
     t.string "name", limit: 255
     t.text "url"
-    t.datetime "last_fetched", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "last_fetched"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "status"
     t.integer "group_id"
     t.bigint "user_id", null: false
@@ -107,8 +107,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_08_01_025234) do
 
   create_table "groups", id: :serial, force: :cascade do |t|
     t.string "name", limit: 255, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["name", "user_id"], name: "index_groups_on_name_and_user_id", unique: true
     t.index ["user_id"], name: "index_groups_on_user_id"
@@ -127,9 +127,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_08_01_025234) do
     t.text "permalink"
     t.text "body"
     t.integer "feed_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.datetime "published", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "published"
     t.boolean "is_read"
     t.boolean "keep_unread", default: false
     t.boolean "is_starred", default: false
@@ -154,8 +154,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_08_01_025234) do
 
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "password_digest", limit: 255
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "api_key", limit: 255, null: false
     t.string "username", null: false
     t.boolean "admin", null: false


### PR DESCRIPTION
Generate migration file to set the default precision to 6 for datetime columns in the database