### PR TITLE
Refactor: Remove memoization from spec test

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -133,6 +133,7 @@ RSpec/ExampleLength:
     - 'spec/commands/fever_api/read_feeds_groups_spec.rb'
     - 'spec/commands/fever_api/read_items_spec.rb'
     - 'spec/helpers/url_helpers_spec.rb'
+    - 'spec/integration/feed_importing_spec.rb'
     - 'spec/models/feed_spec.rb'
     - 'spec/models/migration_status_spec.rb'
     - 'spec/models/story_spec.rb'

--- a/spec/helpers/url_helpers_spec.rb
+++ b/spec/helpers/url_helpers_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe UrlHelpers do
     it "preserves existing absolute urls" do
       content = '<a href="http://foo">bar</a>'
 
-      expect(create_url_helper.expand_absolute_urls(content, nil)).to eq(content)
+      expect(create_url_helper.expand_absolute_urls(content, nil))
+        .to eq(content)
     end
 
     it "replaces relative urls in a, img and video tags" do
@@ -78,7 +79,8 @@ RSpec.describe UrlHelpers do
       ["http", "https"].each do |scheme|
         feed_url = "#{scheme}://blog.golang.org/feed.atom"
 
-        url = create_url_helper.normalize_url("//blog.golang.org/context", feed_url)
+        url = create_url_helper
+              .normalize_url("//blog.golang.org/context", feed_url)
 
         expect(url).to eq("#{scheme}://blog.golang.org/context")
       end

--- a/spec/helpers/url_helpers_spec.rb
+++ b/spec/helpers/url_helpers_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe UrlHelpers do
-  let(:helper) do
+  def create_url_helper
     helper_class = Class.new { include UrlHelpers }
     helper_class.new
   end
@@ -10,7 +10,7 @@ RSpec.describe UrlHelpers do
     it "preserves existing absolute urls" do
       content = '<a href="http://foo">bar</a>'
 
-      expect(helper.expand_absolute_urls(content, nil)).to eq(content)
+      expect(create_url_helper.expand_absolute_urls(content, nil)).to eq(content)
     end
 
     it "replaces relative urls in a, img and video tags" do
@@ -22,7 +22,7 @@ RSpec.describe UrlHelpers do
         </div>
       HTML
 
-      result = helper.expand_absolute_urls(content, "http://oodl.io/d/")
+      result = create_url_helper.expand_absolute_urls(content, "http://oodl.io/d/")
       expect(result.delete("\n")).to eq(<<~HTML.delete("\n"))
         <div>
         <img src="https://foo">
@@ -34,7 +34,7 @@ RSpec.describe UrlHelpers do
     end
 
     it "handles empty body" do
-      expect(helper.expand_absolute_urls("", nil)).to eq("")
+      expect(create_url_helper.expand_absolute_urls("", nil)).to eq("")
     end
 
     it "doesn't modify tags that do not have url attributes" do
@@ -46,7 +46,7 @@ RSpec.describe UrlHelpers do
         </div>
       HTML
 
-      result = helper.expand_absolute_urls(content, "http://oodl.io/d/")
+      result = create_url_helper.expand_absolute_urls(content, "http://oodl.io/d/")
       expect(result.delete("\n")).to eq(<<~HTML.delete("\n"))
         <div>
         <img foo="bar">
@@ -68,7 +68,7 @@ RSpec.describe UrlHelpers do
 
       content = "<a href=\"#{weird_url}\"></a>"
 
-      result = helper.expand_absolute_urls(content, "http://oodl.io/d/")
+      result = create_url_helper.expand_absolute_urls(content, "http://oodl.io/d/")
       expect(result).to include(weird_url)
     end
   end
@@ -78,7 +78,7 @@ RSpec.describe UrlHelpers do
       ["http", "https"].each do |scheme|
         feed_url = "#{scheme}://blog.golang.org/feed.atom"
 
-        url = helper.normalize_url("//blog.golang.org/context", feed_url)
+        url = create_url_helper.normalize_url("//blog.golang.org/context", feed_url)
 
         expect(url).to eq("#{scheme}://blog.golang.org/context")
       end
@@ -86,21 +86,21 @@ RSpec.describe UrlHelpers do
 
     it "leaves urls with a scheme intact" do
       input = "http://blog.golang.org/context"
-      normalized_url = helper.normalize_url(
+      normalized_url = create_url_helper.normalize_url(
         input, "http://blog.golang.org/feed.atom"
       )
       expect(normalized_url).to eq(input)
     end
 
     it "falls back to http if the base_url is also sheme less" do
-      url = helper.normalize_url(
+      url = create_url_helper.normalize_url(
         "//blog.golang.org/context", "//blog.golang.org/feed.atom"
       )
       expect(url).to eq("http://blog.golang.org/context")
     end
 
     it "resolves relative urls" do
-      url = helper.normalize_url(
+      url = create_url_helper.normalize_url(
         "/progrium/dokku/releases/tag/v0.4.4",
         "https://github.com/progrium/dokku/releases.atom"
       )

--- a/spec/helpers/url_helpers_spec.rb
+++ b/spec/helpers/url_helpers_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe UrlHelpers do
-  def create_url_helper
+  def helper
     helper_class = Class.new { include UrlHelpers }
     helper_class.new
   end
@@ -10,8 +10,7 @@ RSpec.describe UrlHelpers do
     it "preserves existing absolute urls" do
       content = '<a href="http://foo">bar</a>'
 
-      expect(create_url_helper.expand_absolute_urls(content, nil))
-        .to eq(content)
+      expect(helper.expand_absolute_urls(content, nil)).to eq(content)
     end
 
     it "replaces relative urls in a, img and video tags" do
@@ -23,7 +22,7 @@ RSpec.describe UrlHelpers do
         </div>
       HTML
 
-      result = create_url_helper.expand_absolute_urls(content, "http://oodl.io/d/")
+      result = helper.expand_absolute_urls(content, "http://oodl.io/d/")
       expect(result.delete("\n")).to eq(<<~HTML.delete("\n"))
         <div>
         <img src="https://foo">
@@ -35,19 +34,19 @@ RSpec.describe UrlHelpers do
     end
 
     it "handles empty body" do
-      expect(create_url_helper.expand_absolute_urls("", nil)).to eq("")
+      expect(helper.expand_absolute_urls("", nil)).to eq("")
     end
 
     it "doesn't modify tags that do not have url attributes" do
       content = <<~HTML
         <div>
         <img foo="bar">
-        <a name="something"/></a>
+        <a name="something"></a>
         <video foo="bar"></video>
         </div>
       HTML
 
-      result = create_url_helper.expand_absolute_urls(content, "http://oodl.io/d/")
+      result = helper.expand_absolute_urls(content, "http://oodl.io/d/")
       expect(result.delete("\n")).to eq(<<~HTML.delete("\n"))
         <div>
         <img foo="bar">
@@ -69,7 +68,7 @@ RSpec.describe UrlHelpers do
 
       content = "<a href=\"#{weird_url}\"></a>"
 
-      result = create_url_helper.expand_absolute_urls(content, "http://oodl.io/d/")
+      result = helper.expand_absolute_urls(content, "http://oodl.io/d/")
       expect(result).to include(weird_url)
     end
   end
@@ -79,8 +78,7 @@ RSpec.describe UrlHelpers do
       ["http", "https"].each do |scheme|
         feed_url = "#{scheme}://blog.golang.org/feed.atom"
 
-        url = create_url_helper
-              .normalize_url("//blog.golang.org/context", feed_url)
+        url = helper.normalize_url("//blog.golang.org/context", feed_url)
 
         expect(url).to eq("#{scheme}://blog.golang.org/context")
       end
@@ -88,21 +86,21 @@ RSpec.describe UrlHelpers do
 
     it "leaves urls with a scheme intact" do
       input = "http://blog.golang.org/context"
-      normalized_url = create_url_helper.normalize_url(
+      normalized_url = helper.normalize_url(
         input, "http://blog.golang.org/feed.atom"
       )
       expect(normalized_url).to eq(input)
     end
 
     it "falls back to http if the base_url is also sheme less" do
-      url = create_url_helper.normalize_url(
+      url = helper.normalize_url(
         "//blog.golang.org/context", "//blog.golang.org/feed.atom"
       )
       expect(url).to eq("http://blog.golang.org/context")
     end
 
     it "resolves relative urls" do
-      url = create_url_helper.normalize_url(
+      url = helper.normalize_url(
         "/progrium/dokku/releases/tag/v0.4.4",
         "https://github.com/progrium/dokku/releases.atom"
       )

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "Story" do
-  let(:story) { build_stubbed(:story) }
-
   describe ".unread" do
     it "returns stories where is_read is false" do
       story = create(:story, :unread)
@@ -25,11 +23,13 @@ RSpec.describe "Story" do
     end
 
     it "uses a fallback string if story has no title" do
+      story = build_stubbed(:story)
       story.title = nil
       expect(story.headline).to eq(Story::UNTITLED)
     end
 
     it "strips html out" do
+      story = build_stubbed(:story)
       story.title = "<b>Super cool</b> stuff"
       expect(story.headline).to eq("Super cool stuff")
     end
@@ -43,17 +43,18 @@ RSpec.describe "Story" do
     end
 
     it "strips html out" do
+      story = build_stubbed(:story)
       story.body = "<a href='http://github.com'>Yo</a> dawg"
       expect(story.lead).to eq("Yo dawg")
     end
   end
 
   describe "#source" do
-    let(:feed) { Feed.new(name: "Superfeed") }
-
-    before { story.feed = feed }
-
     it "returns the feeds name" do
+      story = build_stubbed(:story)
+      feed = Feed.new(name: "Superfeed")
+      story.feed = feed
+
       expect(story.source).to eq(feed.name)
     end
   end

--- a/spec/requests/feeds_controller_spec.rb
+++ b/spec/requests/feeds_controller_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe FeedsController do
 
   describe "#create" do
     context "when the feed url is valid" do
-      let(:feed_url) { "http://example.com/" }
+      feed_url = "http://example.com/"
 
       it "adds the feed and queues it to be fetched" do
         login_as(default_user)
@@ -123,7 +123,7 @@ RSpec.describe FeedsController do
     end
 
     context "when the feed url is invalid" do
-      let(:feed_url) { "http://not-a-valid-feed.com/" }
+      feed_url = "http://not-a-valid-feed.com/"
 
       it "does not add the feed" do
         login_as(default_user)
@@ -136,7 +136,7 @@ RSpec.describe FeedsController do
     end
 
     context "when the feed url is one we already subscribe to" do
-      let(:feed_url) { "http://example.com/" }
+      feed_url = "http://example.com/"
 
       it "does not add the feed" do
         login_as(default_user)

--- a/spec/requests/imports_controller_spec.rb
+++ b/spec/requests/imports_controller_spec.rb
@@ -12,12 +12,10 @@ RSpec.describe ImportsController do
   end
 
   describe "POST /feeds/import" do
-    let(:opml_file) do
-      Rack::Test::UploadedFile.new(
-        "spec/sample_data/subscriptions.xml",
-        "application/xml"
-      )
-    end
+    opml_file = Rack::Test::UploadedFile.new(
+      "spec/sample_data/subscriptions.xml",
+      "application/xml"
+    )
 
     it "parses OPML and starts fetching" do
       expect(Feed::ImportFromOpml).to receive(:call).once


### PR DESCRIPTION
Removed Memoization (let, before, etc.) from specs:
- spec/helpers/url_helpers.rb
- spec/integrations/feed_importing_spec.rb
- spec/models/story_spec.rb
- spec/requests/feeds_controller_spec.rb
- spec/requests/imports_controller_spec.rb