### PR TITLE
Rails8: remove URI.parse

### DIFF
--- a/app/helpers/url_helpers.rb
+++ b/app/helpers/url_helpers.rb
@@ -9,7 +9,7 @@ module UrlHelpers
         url = node.get_attribute(attr)
         next if url =~ URI::RFC2396_PARSER.regexp[:ABS_URI]
 
-        node.set_attribute(attr, URI.join(URI.parse(base_url), url).to_s)
+        node.set_attribute(attr, URI.join(base_url, url).to_s)
       rescue URI::InvalidURIError
         # Just ignore. If we cannot parse the url, we don't want the entire
         # import to blow up.


### PR DESCRIPTION
turns out this wasn't necessary
