### PR TITLE
Rails8: don't pass base to Integer

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
 
   # Cache assets for far-future expiry since they are all digest stamped.
   config.public_file_server.headers = {
-    "cache-control" => "public, max-age=#{Integer(1.year, 10)}"
+    "cache-control" => "public, max-age=#{Integer(1.year)}"
   }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.


### PR DESCRIPTION
It causes an error because we're not passing a string.
