### PR TITLE
Docker: stop running arm64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ github.ref_name == 'main' }}
           tags: |
             ${{ steps.get-tag-latest.outputs.tags }}
             ${{ steps.get-tag-sha.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha


### PR DESCRIPTION
**Why**

It turns out building against `arm64` is not working, at least not when
built from scratch. I've also removed the caching, as it was hiding this
issue.
