### PR TITLE
Docker: re-enable arm64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build_docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.ref_name == 'main' }}
           tags: |
             ${{ steps.get-tag-latest.outputs.tags }}


### PR DESCRIPTION
This switches to `ubuntu-22.04` and reenables arm64 builds. It turns out
there's [an issue with the Github Actions runner image][is]. People seem
to be having luck downgrading the image.

[is]: https://github.com/actions/runner-images/issues/11471
