### PR TITLE
Do not render null if title is nil

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -30,7 +30,7 @@ class Feed < ApplicationRecord
     {
       id:,
       favicon_id: 0,
-      title: name,
+      title: name || "",
       url:,
       site_url: url,
       is_spark: 0,

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -81,5 +81,25 @@ RSpec.describe "Feed" do
         last_updated_on_time: last_fetched.to_i
       )
     end
+
+    it "should replace a null title with an empty string" do
+      last_fetched = 1.day.ago
+      feed = Feed.new(
+        id: 52,
+        name: nil,
+        url: "wat url",
+        last_fetched:
+      )
+
+      expect(feed.as_fever_json).to eq(
+        id: 52,
+        favicon_id: 0,
+        title: "",
+        url: "wat url",
+        site_url: "wat url",
+        is_spark: 0,
+        last_updated_on_time: last_fetched.to_i
+      )
+    end
   end
 end


### PR DESCRIPTION
Newsflash on Gnome and some other apps really don't like if a title is null and crash. This prevents this.