### PR TITLE
Errors: remove port from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec puma -p $PORT -C ./config/puma.rb
+web: bundle exec puma -C ./config/puma.rb
 release: bundle exec rails db:migrate


### PR DESCRIPTION
This is already handled inside of `config/puma.rb`, and it causes a
`NoMethodError` when there is no `PORT` env variable.
