### PR TITLE
remove release phase from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 web: bundle exec puma -C ./config/puma.rb
-release: bundle exec rails db:migrate


### PR DESCRIPTION
It's only relevant to Heroku and prevents use of `foreman` to run
processes. Best to remove it to avoid confusion.
