### PR TITLE
allow urls with non-ASCII characters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "dotenv-rails"
 
 gem "rails", "~> 8.1.0"
 
+gem "addressable"
 gem "bcrypt"
 gem "bootsnap", require: false
 gem "cssbundling-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable
   axe-core-rspec
   bcrypt
   bootsnap

--- a/app/helpers/url_helpers.rb
+++ b/app/helpers/url_helpers.rb
@@ -6,11 +6,13 @@ module UrlHelpers
 
     [["a", "href"], ["img", "src"], ["video", "src"]].each do |tag, attr|
       doc.css("#{tag}[#{attr}]").each do |node|
-        url = node.get_attribute(attr)
-        next if url =~ URI::RFC2396_PARSER.regexp[:ABS_URI]
+        url = Addressable::URI.parse(node.get_attribute(attr))
+        next if url.absolute?
 
-        node.set_attribute(attr, URI.join(base_url, url).to_s)
-      rescue URI::InvalidURIError
+        # normalize percent-encodes any non-ascii (IRI) characters so the
+        # resolved link is a valid URL.
+        node[attr] = Addressable::URI.join(base_url, url).normalize.to_s
+      rescue Addressable::URI::InvalidURIError
         # Just ignore. If we cannot parse the url, we don't want the entire
         # import to blow up.
       end
@@ -22,25 +24,28 @@ module UrlHelpers
   ALLOWED_URL_SCHEMES = ["http", "https"].freeze
 
   def normalize_url(url, base_url)
-    uri = URI.parse(url.strip)
+    uri = Addressable::URI.parse(url.strip)
 
     # resolve (protocol) relative URIs
     if uri.relative?
-      base_uri = URI.parse(base_url.strip)
+      base_uri = Addressable::URI.parse(base_url.strip)
       scheme = base_uri.scheme || "http"
-      uri = URI.join("#{scheme}://#{base_uri.host}", uri)
+      uri = Addressable::URI.parse("#{scheme}://#{base_uri.host}").join(uri)
     end
 
     return if ALLOWED_URL_SCHEMES.exclude?(uri.scheme.downcase)
 
-    uri.to_s
+    # Percent-encode any non-ASCII characters (e.g. an IRI path) so the result
+    # is a valid URL. normalize is idempotent, so already-encoded URLs are
+    # left untouched rather than double-encoded.
+    uri.normalize.to_s
   end
 
   def safe_normalize_url(url, base_url)
     return if url.blank?
 
     normalize_url(url, base_url)
-  rescue URI::InvalidURIError
+  rescue Addressable::URI::InvalidURIError
     nil
   end
 end

--- a/spec/helpers/url_helpers_spec.rb
+++ b/spec/helpers/url_helpers_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe UrlHelpers do
       HTML
     end
 
+    it "percent-encodes non-ascii characters in resolved relative urls" do
+      content = '<a href="/why_no_了/">link</a>'
+
+      result = helper.expand_absolute_urls(content, "http://oodl.io/d/")
+      expect(result).to include('href="http://oodl.io/why_no_%E4%BA%86/"')
+    end
+
     it "handles empty body" do
       expect(helper.expand_absolute_urls("", nil)).to eq("")
     end
@@ -105,6 +112,26 @@ RSpec.describe UrlHelpers do
         "https://github.com/progrium/dokku/releases.atom"
       )
       expect(url).to eq("https://github.com/progrium/dokku/releases/tag/v0.4.4")
+    end
+
+    it "percent-encodes non-ascii (IRI) paths" do
+      url = helper.normalize_url(
+        "https://www.reddit.com/r/ChineseLanguage/comments/1u04wzs/" \
+        "why_no_了_in_the_3rd_one/",
+        "https://www.reddit.com/feed.xml"
+      )
+      expect(url).to eq(
+        "https://www.reddit.com/r/ChineseLanguage/comments/1u04wzs/" \
+        "why_no_%E4%BA%86_in_the_3rd_one/"
+      )
+    end
+
+    it "leaves already-encoded urls intact (no double-encoding)" do
+      input =
+        "https://www.reddit.com/r/ChineseLanguage/comments/1u04wzs/" \
+        "why_no_%E4%BA%86_in_the_3rd_one/"
+      url = helper.normalize_url(input, "https://www.reddit.com/feed.xml")
+      expect(url).to eq(input)
     end
 
     it "returns nil for javascript: scheme" do

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -471,9 +471,20 @@ RSpec.describe StoryRepository do
       expect(described_class.extract_url(entry, feed)).to be_nil
     end
 
-    it "returns nil for an unparseable enclosure_url fallback" do
+    it "preserves a structurally broken (but non-malicious) enclosure_url" do
       feed = double(url: "http://github.com")
       entry = double(url: nil, enclosure_url: "http://[invalid")
+
+      # Only disallowed schemes get dropped. A merely broken URL is kept
+      # (normalize adds the trailing slash) so the bad value stays visible
+      # as a signal rather than being silently turned into nil.
+      expect(described_class.extract_url(entry, feed)).to eq("http://[invalid/")
+    end
+
+    it "returns nil for an unparseable enclosure_url fallback" do
+      feed = double(url: "http://github.com")
+      # A space in the host is rejected outright by the parser.
+      entry = double(url: nil, enclosure_url: "http://exa mple.com")
 
       expect(described_class.extract_url(entry, feed)).to be_nil
     end


### PR DESCRIPTION
The recent change to limit URL schemes also broke URLs with non-ASCII
characters. This url encodes them instead.
