### PR TITLE
add story grouping

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -50,6 +50,12 @@ Lint/NumberConversion:
     - 'spec/models/story_spec.rb'
 
 # Offense count: 1
+# Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
+Metrics/ClassLength:
+  Exclude:
+    - 'app/repositories/story_repository.rb'
+
+# Offense count: 1
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -22,6 +22,8 @@ class ProfilesController < ApplicationController
   private
 
   def user_params
-    params.expect(user: [:username, :password_challenge, :stories_order])
+    params.expect(
+      user: [:username, :password_challenge, :stories_order, :group_stories]
+    )
   end
 end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -3,7 +3,14 @@
 class StoriesController < ApplicationController
   def index
     order = current_user.stories_order
-    @unread_stories = authorization.scope(StoryRepository.unread(order:))
+    scope =
+      if current_user.group_stories
+        StoryRepository.unread_grouped_by_feed(order:)
+      else
+        StoryRepository.unread(order:)
+      end
+
+    @unread_stories = authorization.scope(scope)
   end
 
   def update

--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -50,6 +50,17 @@ class StoryRepository
     Story.where(is_read: false).order("published #{order}").includes(:feed)
   end
 
+  # Keeps each feed's stories adjacent, with the feeds that have the most
+  # unread stories first. `feed_id` is the stable tie-break that holds a feed's
+  # stories together; `order` controls the published direction within a feed.
+  def self.unread_grouped_by_feed(order: "desc")
+    Story.where(is_read: false)
+         .order(Arel.sql("count(*) OVER (PARTITION BY feed_id) DESC"))
+         .order(:feed_id)
+         .order(published: order)
+         .includes(:feed)
+  end
+
   def self.unread_since_id(since_id)
     unread.where(Story.arel_table[:id].gt(since_id))
   end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -5,6 +5,8 @@
     <legend><%= t(".stories_feed_settings") %></legend>
     <%= form.label :stories_order %>
     <%= form.select :stories_order, User.stories_orders.transform_keys {|k| User.human_attribute_name("stories_order.#{k}") } %>
+    <%= form.label :group_stories %>
+    <%= form.check_box :group_stories %>
   </fieldset>
   <%= form.submit("Update") %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -189,6 +189,7 @@ en:
   activerecord:
     attributes:
       user:
+        group_stories: "Group stories by feed"
         stories_order: "Stories feed order"
       user/stories_order:
         asc: "Oldest first"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -188,6 +188,7 @@ zh-TW:
   activerecord:
     attributes:
       user:
+        group_stories: "依來源分組文章"
         stories_order: "文章排序方式"
       user/stories_order:
         asc: "最舊優先"

--- a/db/migrate/20260609120000_add_group_stories_to_users.rb
+++ b/db/migrate/20260609120000_add_group_stories_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGroupStoriesToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :group_stories, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_09_172408) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_09_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -171,6 +171,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_09_172408) do
     t.string "username", null: false
     t.boolean "admin", null: false
     t.string "stories_order", default: "desc"
+    t.boolean "group_stories", default: false, null: false
     t.index ["api_key"], name: "index_users_on_api_key", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -276,6 +276,34 @@ RSpec.describe StoryRepository do
     end
   end
 
+  describe ".unread_grouped_by_feed" do
+    it "keeps a feed's stories adjacent, most-unread feed first" do
+      feed_few = create(:feed)
+      feed_many = create(:feed)
+      lonely = create(:story, feed: feed_few, published: 1.day.ago)
+      newer = create(:story, feed: feed_many, published: 2.days.ago)
+      older = create(:story, feed: feed_many, published: 3.days.ago)
+
+      expect(described_class.unread_grouped_by_feed)
+        .to eq([newer, older, lonely])
+    end
+
+    it "orders stories within a feed by the given direction" do
+      feed = create(:feed)
+      older = create(:story, feed:, published: 2.days.ago)
+      newer = create(:story, feed:, published: 1.day.ago)
+
+      expect(described_class.unread_grouped_by_feed(order: "asc"))
+        .to eq([older, newer])
+    end
+
+    it "does not return read stories" do
+      create(:story, :read)
+
+      expect(described_class.unread_grouped_by_feed).to be_empty
+    end
+  end
+
   describe ".unread_since_id" do
     it "returns unread stories with id greater than given id" do
       story1 = create(:story)

--- a/spec/requests/stories_controller_spec.rb
+++ b/spec/requests/stories_controller_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe StoriesController do
 
       expect(rendered).to have_css("#zen")
     end
+
+    it "groups stories by feed when the user enables grouping" do
+      default_user.update!(group_stories: true)
+      login_as(default_user)
+      create(:story)
+
+      get "/news"
+
+      expect(rendered).to have_css("#stories")
+    end
   end
 
   describe "#archived" do

--- a/spec/system/profile_spec.rb
+++ b/spec/system/profile_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe "profile page" do
     expect(page).to have_select("Stories feed order", selected: "Oldest first")
   end
 
+  it "allows the user to group stories by feed" do
+    check("Group stories by feed")
+    click_on("Update")
+
+    expect(default_user.reload.group_stories).to be(true)
+  end
+
   it "rejects username change with wrong password" do
     fill_in_username_fields("wrong_password")
     click_on("Update username")

--- a/spec/system/stories_index_spec.rb
+++ b/spec/system/stories_index_spec.rb
@@ -183,6 +183,21 @@ RSpec.describe "stories/index" do
     expect(titles).to eq(["Older Story", "Newer Story"])
   end
 
+  it "groups stories by feed when the user enables grouping" do
+    default_user.update!(group_stories: true)
+    feed_few = create(:feed)
+    feed_many = create(:feed)
+    create(:story, feed: feed_few, title: "Lonely", published: 1.day.ago)
+    create(:story, feed: feed_many, title: "Pair A", published: 2.days.ago)
+    create(:story, feed: feed_many, title: "Pair B", published: 3.days.ago)
+    login_as(default_user)
+
+    visit news_path
+
+    titles = all(".story-title").map(&:text)
+    expect(titles).to eq(["Pair A", "Pair B", "Lonely"])
+  end
+
   it "shows the unread count in the page title" do
     create(:story, title: "My Story")
     login_as(default_user)


### PR DESCRIPTION
On the user profile page we can now toggle grouping stories by feed.
This allows a flow where there is less jumping across feeds while
reading.
